### PR TITLE
Add a local WP environment for developing the packages

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Install dependencies
         run: composer install
       - name: Run lint
-        run: ./vendor/bin/phpcs -q --report=checkstyle | cs2pr
+        run: composer run phpcs -- -q --report=checkstyle | cs2pr
       - name: Run tests
         run: composer run phpunit
       - name: Run static analysis
-        run: ./vendor/bin/phpstan --error-format=checkstyle --memory-limit=1G analyse | cs2pr
+        run: composer run phpstan -- --error-format=checkstyle --memory-limit=1G | cs2pr
       - name: Run coverage-check
         run: composer run coverage-check

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,13 @@ node_modules
 /packages/*/build
 .turbo
 /composer.lock
+
+# Docker WP Image tends to add these plugins...
+packages/akismet
+packages/hello.php
+packages/index.php
+
+# MU-Plugins & Themes are managed via composer
+/docker/wordpress/mu-plugins/*
+/docker/wordpress/themes/*
+!/docker/wordpress/mu-plugins/plugin-loader.php

--- a/Readme.md
+++ b/Readme.md
@@ -4,8 +4,7 @@ This is the BoxUK mono-repo for our WordPress packages. The [WordPress Skeleton]
 
 ## How to use
 
-This mono repo allows you to develop any of the packages. At the moment, there's not any way to run the code in
-WordPress, so that's currently left as an open issue for someone to address. PR's welcome!
+This mono repo allows you to develop any of the packages. To start a WordPress development environment to test against, just run `docker-compose up -d wordpress` and you'll be able to access WordPress at [http://localhost:8000](http://localhost:8000). 
 
 We use [Monorepo Builder](https://github.com/symplify/monorepo-builder) tools to manage the mono-repo dependancies. 
 
@@ -26,7 +25,7 @@ bin/composer install <package-name>
 
 ## Adding a package
 
-Packages will require their own folder to be setup, with a `composer.json` file at the root of the package. In order for your package to be published, you'll also need to modify `/.github/workflows/packages.yml` to configure the package name and the target repository for publishing. This will automate pushing changes of the package out to the target repository, but you may need further work to ensure that repository is available via `composer` in your projects. 
+To create a package, you can run `bin/create-package <package-name>` and this will scaffold out all the necessary changes needed. In order for your package to be published, you'll also need to modify `/.github/workflows/packages.yml` to configure the package name and the target repository for publishing. This will automate pushing changes of the package out to the target repository, but you may need further work to ensure that repository is available via `composer` in your projects. 
 
 ## Tests
 
@@ -36,8 +35,8 @@ All packages need to have 100% test coverage. During CI they will be tested for 
 
 If your package requires javascript, you can also setup a `package.json` file in the root of the package. Much like `composer.json`, this will be merged automatically at the root level. 
 
-To run `npm` commands directly in your package run `bin/npm -w pacakges/<package-name>` with your command. For example `bin/npm -w packages/iconography run test` would run tests specifically in the iconography package. 
+To run `npm` commands directly in your package run `bin/npm -w packages/<package-name>` with your command. For example `bin/npm -w packages/iconography run test` would run tests specifically in the iconography package. 
 
-Commands can also be run globally across all packages using `turbo`. This is setup so that if you run `bin/npm run test` it will run test in every package that has a `pacakge.json` file with a `test` script. You should try to keep naming consistent across packages to support this work. All currently supported scripts in `turbo` are listed in the `turbo.json` file at the root. 
+Commands can also be run globally across all packages using `turbo`. This is setup so that if you run `bin/npm run test` it will run test in every package that has a `package.json` file with a `test` script. You should try to keep naming consistent across packages to support this work. All currently supported scripts in `turbo` are listed in the `turbo.json` file at the root. 
 
 During CI, the `lint`, `test` and `build` NPM scripts are run to validate the package quality. You should ensure your package supports these. 

--- a/bin/composer
+++ b/bin/composer
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose run --rm php composer "$@"
+./bin/php composer "$@"

--- a/bin/create-package
+++ b/bin/create-package
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+set -e
+
+PACKAGE_NAME=$1 
+
+if [ -z "$PACKAGE_NAME" ]; then
+    echo "Usage: $0 <package-name>"
+    exit 1
+fi
+
+# Validate the package name is in kebab-case
+if [[ ! $PACKAGE_NAME =~ ^[a-z0-9-]+$ ]]; then
+    echo "Package name must be in lowercase with hyphens only"
+    exit 1
+fi
+
+if [ -d "./packages/$PACKAGE_NAME" ]; then
+    echo "Package already exists at ./packages/$PACKAGE_NAME"
+    exit 1
+fi
+
+# Convert the package name to PascalCase
+# Can't use `sed` as the `\U` flag is not supported on MacOS.
+PASCAL_PACKAGE_NAME=$(echo $PACKAGE_NAME | awk -F- '{for(i=1;i<=NF;i++){ $i=toupper(substr($i,1,1)) substr($i,2) }}1' OFS="")
+
+# Create the necessary directories etc...
+mkdir -p ./packages/$PACKAGE_NAME
+mkdir -p ./packages/$PACKAGE_NAME/src
+mkdir -p ./packages/$PACKAGE_NAME/tests
+
+cat <<EOT >> ./packages/$PACKAGE_NAME/Readme.md
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead: https://github.com/boxuk/wp-packages
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!
+EOT
+
+touch ./packages/$PACKAGE_NAME/.deployignore
+
+cat <<EOT >> ./packages/$PACKAGE_NAME/composer.json
+{
+
+    "name": "boxuk/$PACKAGE_NAME",
+    "type": "wordpress-muplugin",
+    "autoload": {
+        "psr-4": {
+            "Boxuk\\\\${PASCAL_PACKAGE_NAME}\\\\": "src"
+        }
+    },
+    "authors": [
+        {
+            "name": "BoxUK",
+            "email": "developers@boxuk.com"
+        }
+    ],
+    "require": {}
+}
+EOT
+
+cat <<EOT >> ./packages/$PACKAGE_NAME/$PACKAGE_NAME.php
+<?php
+/**
+ * Plugin Name: $PASCAL_PACKAGE_NAME
+ * Description: A brief description of the plugin.
+ * Version: 1.0.0
+ * Author: BoxUK
+ * Author URI: https://boxuk.com
+ * 
+ * @package Boxuk\\${PASCAL_PACKAGE_NAME}
+ */
+
+declare( strict_types=1 );
+
+namespace Boxuk\\${PASCAL_PACKAGE_NAME};
+
+// Your code here
+
+EOT
+
+# Add the package to the mono-repo config. 
+bin/composer run mono:merge
+
+# Modify the auto-load paths (the default is /packages/$PACKAGE_NAME/src), but we need it to be /plugins/$PACKAGE_NAME/src
+sed -i '' -e "s/packages\/$PACKAGE_NAME\/src/plugins\/$PACKAGE_NAME\/src/g" composer.json
+
+bin/composer dump-autoload
+
+echo ""
+echo "Package created at ./packages/$PACKAGE_NAME"
+echo "Please update the .github/workflows/packages.yml file to include the new package in the build process."
+echo ""

--- a/bin/nodejs
+++ b/bin/nodejs
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose run --rm nodejs "$@"

--- a/bin/npm
+++ b/bin/npm
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-docker-compose run --rm nodejs npm "$@"
+bin/nodejs npm "$@"

--- a/bin/php
+++ b/bin/php
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker-compose run --rm php "$@"

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,20 @@
 {
     "name": "boxuk/wp-packages",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "BoxUK",
             "email": "developers@boxuk.com"
+        }
+    ],
+    "repositories": [
+        {
+            "only": [
+                "wpackagist-plugin/*",
+                "wpackagist-theme/*"
+            ],
+            "type": "composer",
+            "url": "https://wpackagist.org"
         }
     ],
     "require": {
@@ -24,13 +35,15 @@
         "permafrost-dev/coverage-check": "^2.0",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
         "symplify/monorepo-builder": "^11.2",
-        "szepeviktor/phpstan-wordpress": "^1.3"
+        "szepeviktor/phpstan-wordpress": "^1.3",
+        "wpackagist-plugin/sqlite-database-integration": "^2.0",
+        "wpackagist-theme/twentytwentyfour": "^1.0"
     },
     "autoload": {
         "psr-4": {
             "Boxuk\\BoxWpEditorTools\\": [
-                "packages/editor-tools/src/",
-                "packages/wp-editor-tools/src/"
+                "packages/editor-tools/src",
+                "plugins/editor-tools/src/"
             ]
         }
     },
@@ -39,8 +52,21 @@
         "boxuk/wp-iconography": "self.version"
     },
     "config": {
+        "vendor-dir": "packages/vendor",
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/installers": true
+        }
+    },
+    "extra": {
+        "installer-paths": {
+            "docker/wordpress/mu-plugins/{$name}": [
+                "type:wordpress-muplugin",
+                "type:wordpress-plugin"
+            ],
+            "docker/wordpress/themes/{$name}": [
+                "type:wordpress-theme"
+            ]
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,22 @@ version: '3.1'
 services:
   php:
     build: ./docker/php
-    working_dir: /usr/src/app
+    working_dir: /var/www/html
     volumes: 
-      - .:/usr/src/app
+      - .:/var/www/html
   nodejs:
     build: ./docker/nodejs
     working_dir: /usr/src/app
     volumes: 
       - .:/usr/src/app
+
+  wordpress:
+    build: ./docker/wordpress
+    ports:
+      - "8000:80"
+    volumes:
+      - ./docker/wordpress/wp-config.php:/var/www/html/wp-config.php
+      - ./docker/wordpress/db.php:/var/www/html/wp-content/db.php
+      - ./docker/wordpress/mu-plugins/:/var/www/html/wp-content/mu-plugins/
+      - ./docker/wordpress/themes:/var/www/html/wp-content/themes/
+      - ./packages/:/var/www/html/wp-content/plugins/

--- a/docker/wordpress/Dockerfile
+++ b/docker/wordpress/Dockerfile
@@ -1,0 +1,1 @@
+FROM wordpress:6.5.3

--- a/docker/wordpress/db.php
+++ b/docker/wordpress/db.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Plugin Name: SQLite integration (Drop-in)
+ * Version: 1.0.0
+ * Author: WordPress Performance Team
+ * Author URI: https://make.wordpress.org/performance/
+ *
+ * This file is auto-generated and copied from the sqlite plugin.
+ * Please don't edit this file directly.
+ *
+ * @package wp-sqlite-integration
+ */
+
+define( 'SQLITE_DB_DROPIN_VERSION', '1.8.0' );
+
+// Bail early if the SQLite implementation was not located in the plugin.
+if ( ! file_exists( ABSPATH . 'wp-content/mu-plugins/sqlite-database-integration/wp-includes/sqlite/db.php' ) ) {
+	return;
+}
+
+// Define SQLite constant.
+if ( ! defined( 'DATABASE_TYPE' ) ) {
+	define( 'DATABASE_TYPE', 'sqlite' );
+}
+
+// Require the implementation from the plugin.
+require_once ABSPATH . 'wp-content/mu-plugins/sqlite-database-integration/wp-includes/sqlite/db.php';
+
+// Activate the performance-lab plugin if it is not already activated.
+add_action(
+	'admin_footer',
+	function () {
+		if ( defined( 'SQLITE_MAIN_FILE' ) ) {
+			return;
+		}
+		if ( ! function_exists( 'activate_plugin' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		if ( is_plugin_inactive( 'sqlite-database-integration' ) ) {
+			activate_plugin( 'sqlite-database-integration' );
+		}
+	}
+);

--- a/docker/wordpress/mu-plugins/plugin-loader.php
+++ b/docker/wordpress/mu-plugins/plugin-loader.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * A plugin loader for WordPress.
+ * 
+ * @package BoxUK/WP
+ */
+
+// Define the path to the mu-plugins directory.
+define( 'MU_PLUGINS_DIR', __DIR__ );
+
+/**
+ * Nothing fancy here. Just `require_once` the necessary plugin files.
+ */

--- a/docker/wordpress/wp-config.php
+++ b/docker/wordpress/wp-config.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * The base configuration for WordPress
+ *
+ * The wp-config.php creation script uses this file during the installation.
+ * You don't have to use the web site, you can copy this file to "wp-config.php"
+ * and fill in the values.
+ *
+ * This file contains the following configurations:
+ *
+ * * Database settings
+ * * Secret keys
+ * * Database table prefix
+ * * ABSPATH
+ *
+ * @link https://wordpress.org/support/article/editing-wp-config-php/
+ *
+ * @package WordPress
+ */
+
+define( 'DATABASE_TYPE', 'sqlite' );
+define( 'DB_DIR', '/var/www/html/wp-content/database' );
+define( 'DB_FILE', 'wordpress.db' );
+
+define( 'AUTH_KEY', 'uDh8?//l(9c$Qu`NRD4H3k426U3V}x!I#{pbFV7Z!1eT)T$[+6Go)Gpg?K5Z|R{D' );
+define( 'SECURE_AUTH_KEY', 'nGAeRQI%DhdGhMoT.{Ba(&V5D[Z7FDO@NHRX_d3;q~S+jko-tsA; `+~6!<r_X>b' );
+define( 'LOGGED_IN_KEY', 'cqiEHUYDtHxsqW=w|_.g{uCL2cifNJMi_WL2yf?sn)=UF+6nhO>a-qKLH75bZ)n1' );
+define( 'NONCE_KEY', ';H#]ee;nLS~h l~Oy(p|1f<@-;yG1%Y{ h(P8-T<(9X+M(?uUkD)obyL+R[)<Z4z' );
+define( 'AUTH_SALT', 'pjVYn-F]kG%^)##=3^Y@_bH@OW~3#fp:D;B-+#skTM{W+|MtedR|qVn%hQ3Iv2 &' );
+define( 'SECURE_AUTH_SALT', ')C4@PV(d:DU0}i{,P[r.mrjfwyX!>kZvvhRW$|QZQ;S&8&Rep.N$*E938l9bxi`m' );
+define( 'LOGGED_IN_SALT', '%V}O=GU*_{),8)-n-DXKhZXhqeu}lR1U0oA,#f+=7br+&g2TAE_>ZL-,ogsWuedO' );
+define( 'NONCE_SALT', 'dm[=a6+2b1rHuGW=xE`#-<}<w_ -dnmdvM%:ZcxLCCPtq2>o{}NlqT>4<kL6nX-#' );
+
+/**#@-*/
+$table_prefix = 'wp_'; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+define( 'WP_DEBUG', true );
+define( 'WP_SCRIPT_DEBUG', true );
+
+/** Absolute path to the WordPress directory. */
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', __DIR__ . '/' );
+}
+
+/** Sets up WordPress vars and included files. */
+require_once ABSPATH . 'wp-content/plugins/vendor/autoload.php';
+require_once ABSPATH . 'wp-settings.php';

--- a/monorepo-builder.php
+++ b/monorepo-builder.php
@@ -2,8 +2,53 @@
 
 declare(strict_types=1);
 
+use Symplify\MonorepoBuilder\ComposerJsonManipulator\ValueObject\ComposerJsonSection;
 use Symplify\MonorepoBuilder\Config\MBConfig;
 
 return static function ( MBConfig $config ): void {
-	$config->packageDirectories( array( __DIR__ . '/packages' ) );
+	$config->packageDirectories( [ __DIR__ . '/packages' ] );
+	$config->packageDirectoriesExcludes( [ __DIR__ . '/packages/vendor' ] );
+
+	$config->dataToAppend([ 
+		ComposerJsonSection::AUTHORS => [
+			[
+				'name' => 'BoxUK',
+				'email' => 'developers@boxuk.com'
+			],
+		],
+		ComposerJsonSection::REPOSITORIES => [ 
+			[
+				'type' => 'composer',
+				'url' => 'https://wpackagist.org',
+				'only' => ['wpackagist-plugin/*', 'wpackagist-theme/*'],
+			],
+		],
+		ComposerJsonSection::REQUIRE_DEV => [
+			'automattic/vipwpcs' => '^3.0',
+			'permafrost-dev/coverage-check' => '^2.0',
+			'phpcompatibility/phpcompatibility-wp' => '^2.1',
+			'symplify/monorepo-builder' => '^11.2',
+			'szepeviktor/phpstan-wordpress' => '^1.3',
+			'wpackagist-plugin/sqlite-database-integration' => '^2.0',
+			'wpackagist-theme/twentytwentyfour' => '^1.0',
+		],
+		ComposerJsonSection::CONFIG => [
+			'vendor-dir' => 'packages/vendor',
+			'allow-plugins' => [
+				'dealerdirect/phpcodesniffer-composer-installer' => true,
+				'composer/installers' => true,
+			],
+		],
+		ComposerJsonSection::EXTRA => [ 
+			'installer-paths' => [
+				"docker/wordpress/mu-plugins/{\$name}" => [
+					"type:wordpress-plugin",
+					"type:wordpress-muplugin"
+				],
+				"docker/wordpress/themes/{\$name}" => [
+					"type:wordpress-theme"
+				]
+			]
+		]
+	]);
 };

--- a/packages/editor-tools/composer.json
+++ b/packages/editor-tools/composer.json
@@ -3,7 +3,7 @@
     "type": "wordpress-muplugin",
     "autoload": {
         "psr-4": {
-            "Boxuk\\BoxWpEditorTools\\": "src/"
+            "Boxuk\\BoxWpEditorTools\\": "src"
         }
     },
     "authors": [

--- a/packages/editor-tools/editor-tools.php
+++ b/packages/editor-tools/editor-tools.php
@@ -1,17 +1,20 @@
 <?php
 /**
  * Plugin Name: Boxuk Editor Tools
- * Plugin URI: https://boxuk.com
  * Description: A collection of tools to enhance the WordPress editor.
+ * Version: 1.0.0
+ * Author: BoxUK
+ * Author URI: https://boxuk.com
  * 
  * @package Boxuk\BoxWpEditorTools
  */
 
 declare( strict_types = 1 );
+namespace Boxuk\BoxWpEditorTools;
 
-( new \Boxuk\BoxWpEditorTools\BlockLoader() )->init();
-( new \Boxuk\BoxWpEditorTools\Comments() )->init();
-( new \Boxuk\BoxWpEditorTools\EditorCleanup() )->init();
-( new \Boxuk\BoxWpEditorTools\PostTypes() )->init();
-( new \Boxuk\BoxWpEditorTools\TemplatePersistence() )->init(); 
-( new \Boxuk\BoxWpEditorTools\Security\Security() )->init();
+( new BlockLoader() )->init();
+( new Comments() )->init();
+( new EditorCleanup() )->init();
+( new PostTypes() )->init();
+( new TemplatePersistence() )->init(); 
+( new Security\Security() )->init();

--- a/packages/iconography/iconography.php
+++ b/packages/iconography/iconography.php
@@ -1,13 +1,17 @@
 <?php
 /**
  * Plugin Name: Iconography
+ * Description: Provides iconography for the block editor.
+ * Version: 1.0.0
+ * Author: BoxUK
+ * Author URI: https://www.boxuk.com
  * 
- * @package Peake\Client\Mu\Plugins\Iconography
+ * @package Boxuk\Iconography
  */
 
 declare ( strict_types = 1 );
 
-namespace Peake\Client\Mu\Plugins\Iconography;
+namespace Boxuk\Iconography;
 
 /**
  * Loads Iconography

--- a/packages/iconography/tests/TestIcononography.php
+++ b/packages/iconography/tests/TestIcononography.php
@@ -2,12 +2,12 @@
 /**
  * Test Iconography class
  * 
- * @package Peake\Client\Mu\Plugins\Iconography
+ * @package Boxuk\Iconography
  */
 
 declare( strict_types = 1 );
 
-namespace Peake\Client\Mu\Plugins\Iconography;
+namespace Boxuk\Iconography;
 
 use WP_Mock\Tools\TestCase;
 

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -20,6 +20,7 @@
 	<exclude-pattern>/build</exclude-pattern>
 	<exclude-pattern>/node_modules</exclude-pattern>
 	<exclude-pattern>/coverage</exclude-pattern>
+	<exclude-pattern>/packages/index.php</exclude-pattern>
 
 	<rule ref="WordPress-VIP-Go">
 		<!-- Remove this so we can use PSR-4 autoloading -->

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,11 +1,13 @@
 includes:
-    - vendor/szepeviktor/phpstan-wordpress/extension.neon
+    - packages/vendor/szepeviktor/phpstan-wordpress/extension.neon
 parameters:
   level: 9
   bootstrapFiles: [ tests/bootstrap-phpstan.php ]
   paths:
-    - packages/
+    - packages
   excludePaths:
     analyse:
-      - vendor
+      - packages/vendor
       - /**/tests/*
+    analyseAndScan:
+      - packages/vendor/10up/wp_mock # WP_Mock functions override the signatures from php-stubs/wordpress

--- a/tests/bootstrap-phpunit.php
+++ b/tests/bootstrap-phpunit.php
@@ -8,5 +8,5 @@
 declare ( strict_types=1 );
  
 $root_dir = dirname( __DIR__ );
-require_once $root_dir . '/vendor/autoload.php';
+require_once $root_dir . '/packages/vendor/autoload.php';
 WP_Mock::bootstrap();


### PR DESCRIPTION
Sets up a local WordPress environment for running your packages in during development. 
- Uses the WordPress docker image to provide WordPress
- Uses an SQLite database to avoid needing to setup a whole DB server etc. 
- Mounts packages in to `/wp-content/plugins` so that you can enable/disable the packages as you work on them. 
- Adds a `bin/create-package` command to allow quickly creating a new package.
- A few misc tidy-ups to support the WP environment