### PR TITLE
[FIX] Fix for multiple posts included in query-include-exclude package

### DIFF
--- a/.github/workflows/tests-js.yml
+++ b/.github/workflows/tests-js.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [18, 20, 21, 22]
+        node-version: [20]
     name: Test JS (node ${{ matrix.node-version }})
     steps:
       - name: Checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "packages/*"
       ],
       "devDependencies": {
-        "turbo": "^2.0.7"
+        "turbo": "^2.0.7",
+        "webpack-cli": "^5.1.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3109,6 +3110,16 @@
       "integrity": "sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==",
       "dev": true
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "dev": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@puppeteer/browsers": {
       "version": "1.4.6",
       "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-1.4.6.tgz",
@@ -5046,72 +5057,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/api-fetch": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.3.0.tgz",
-      "integrity": "sha512-VpHG+9cLRZG13V2t1+xXpwuHJCeqiOl0ent9qXzbe6am9DtKSJ3oxiNdZaHjs6tdgGNuN/mTowRi5ceYJZb83Q==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/url": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/api-fetch/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/api-fetch/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/autop": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-4.3.0.tgz",
-      "integrity": "sha512-ml34lWwTPZwD2QYTRcecC94KC/V4SBHaCetlEUz0GPzhyfi48Zku6RCoebMDmayqYlme1iF/4quC4zOA0QLoAg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/babel-plugin-import-jsx-pragma": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-4.41.0.tgz",
@@ -5153,867 +5098,6 @@
       "integrity": "sha512-yFRYqNtd26ULZ0oAHhCu/IcaA0XHI3E7kRCKajZqUvyRQj7YprXnpD3o0/pnwvF6ZFTXzCX8pXHjUc2TIv97ig==",
       "dev": true
     },
-    "node_modules/@wordpress/blob": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-4.3.0.tgz",
-      "integrity": "sha512-4BQMpcamwx/2rYGZpvcrmddTuo+hXnDtiylvzP0vAnukJ9p1ae2MGJrWCRNp1qNo/hRbyq8lzA43wgOFxKkp0g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-13.3.0.tgz",
-      "integrity": "sha512-z83dKTRSeTe0SbyECQ3LQ3f+6Wqv01Y861f9g9vXQdSobrOH3Q0sBUO90ulcfEC4fna57nIi70SgaCG+aXJGUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@emotion/react": "^11.7.1",
-        "@emotion/styled": "^11.6.0",
-        "@react-spring/web": "^9.4.5",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/api-fetch": "^7.3.0",
-        "@wordpress/blob": "^4.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/commands": "^1.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keyboard-shortcuts": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/notices": "^5.3.0",
-        "@wordpress/preferences": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/style-engine": "^2.3.0",
-        "@wordpress/token-list": "^3.3.0",
-        "@wordpress/url": "^4.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "@wordpress/wordcount": "^4.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "deepmerge": "^4.3.0",
-        "diff": "^4.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "postcss": "^8.4.21",
-        "postcss-prefixwrap": "^1.41.0",
-        "postcss-urlrebase": "^1.4.0",
-        "react-autosize-textarea": "^7.1.0",
-        "react-easy-crop": "^5.0.6",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-editor/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/block-serialization-default-parser": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-5.3.0.tgz",
-      "integrity": "sha512-H9xXMIqShBdMbt2cRmct+nDy/dzX9last1j3kwJ5Gr0WfvgSLXQOk3p7jnCYYbixgK08VzLvkfqEofg314QSbg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks": {
-      "version": "13.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-13.3.0.tgz",
-      "integrity": "sha512-Df0aW+IardBoiWwLopqex450s7HQjP+QRfD4Pi8Skr5ELuVxwPRAJK9Dv4X2eLQyEPIucErIBjgW6tcSXNIhQQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/autop": "^4.3.0",
-        "@wordpress/blob": "^4.3.0",
-        "@wordpress/block-serialization-default-parser": "^5.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/shortcode": "^4.3.0",
-        "change-case": "^4.1.2",
-        "colord": "^2.7.0",
-        "fast-deep-equal": "^3.1.3",
-        "hpq": "^1.3.0",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-is": "^18.3.0",
-        "remove-accents": "^0.5.0",
-        "showdown": "^1.9.1",
-        "simple-html-tokenizer": "^0.5.7",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/blocks/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/browserslist-config": {
       "version": "5.41.0",
       "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-5.41.0.tgz",
@@ -6021,451 +5105,6 @@
       "dev": true,
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/@wordpress/commands": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-1.3.0.tgz",
-      "integrity": "sha512-6toFSZTYfNPqHBG2IxuClZ7uZpuXsV7kJRjC+liy3ew1U6vG/Xx9Ps4gvUT1lun6uRsYmftTEqV9GUz2V6IadA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/keyboard-shortcuts": "^5.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "clsx": "^2.1.1",
-        "cmdk": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/commands/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/components": {
@@ -6571,354 +5210,6 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/core-data": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-7.3.0.tgz",
-      "integrity": "sha512-qPgb0bWgUQs2QSa4QJGtu2mceC80r4MAbFtZaBYWlv7CQ8qrgx0KJodSaMdezMqBGuQM/+7oS51A6jtR+SKX0g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^7.3.0",
-        "@wordpress/block-editor": "^13.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/sync": "^1.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "@wordpress/url": "^4.3.0",
-        "change-case": "^4.1.2",
-        "equivalent-key-map": "^0.2.2",
-        "fast-deep-equal": "^3.1.3",
-        "memize": "^2.1.0",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/core-data/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/data": {
       "version": "9.28.0",
       "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
@@ -6948,452 +5239,6 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/dataviews": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dataviews/-/dataviews-3.0.0.tgz",
-      "integrity": "sha512-UlNeB0hS6ooGEXcJTP8c6az25Ku5t4kz4B+mnaiBd9HpisBOIaLtTRaDgtS0ioKm+nhvLjGwDQlVuNRMZXW7mQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "clsx": "^2.1.1",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/dataviews/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/date": {
       "version": "4.58.0",
       "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-4.58.0.tgz",
@@ -7407,21 +5252,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-5.9.0.tgz",
-      "integrity": "sha512-hXbCkbG1XES47t7hFSETRrLfaRSPyQPlCnhlCx7FfhYFD0wh1jVArApXX5dD+A6wTrayXX/a16MpfaNqE662XA==",
-      "dev": true,
-      "dependencies": {
-        "json2php": "^0.0.7"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/@wordpress/deprecated": {
@@ -7448,550 +5278,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/dom-ready": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.3.0.tgz",
-      "integrity": "sha512-zuLLMIeJt1hZ95R4kdJFcsIaL2eud1kF40VCmwK3mK0qpgXv/1avtGX8lx6DMLL/GGL1yYcJhR13RSKSjxuGEQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.26.0.tgz",
-      "integrity": "sha512-4KFyQ3IsYIJaIvOQ1qhAHhRISs9abNToF/bktfMNxQiEJsmbNn7lq/IbaY+shqwdBWVg8TQtLcL4MpSl0ISaxQ==",
-      "dev": true,
-      "dependencies": {
-        "@wordpress/api-fetch": "^6.55.0",
-        "@wordpress/keycodes": "^3.58.0",
-        "@wordpress/url": "^3.59.0",
-        "change-case": "^4.1.2",
-        "form-data": "^4.0.0",
-        "get-port": "^5.1.1",
-        "lighthouse": "^10.4.0",
-        "mime": "^3.0.0",
-        "web-vitals": "^3.5.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "@playwright/test": ">=1"
-      }
-    },
-    "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/@wordpress/api-fetch": {
-      "version": "6.55.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
-      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^4.58.0",
-        "@wordpress/url": "^3.59.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/e2e-test-utils-playwright/node_modules/@wordpress/url": {
-      "version": "3.59.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
-      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/editor": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-14.3.0.tgz",
-      "integrity": "sha512-OdT3V9eQrWBKvC3/HJFeDt/tphsdgq1cZ/p5n4dyH/hkssprvXTPQebu6TJM9G3v+Rm/GgpM9T3NieUOaBQHgA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/api-fetch": "^7.3.0",
-        "@wordpress/blob": "^4.3.0",
-        "@wordpress/block-editor": "^13.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/commands": "^1.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/core-data": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/dataviews": "^3.0.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/interface": "^6.3.0",
-        "@wordpress/keyboard-shortcuts": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/media-utils": "^5.3.0",
-        "@wordpress/notices": "^5.3.0",
-        "@wordpress/patterns": "^2.3.0",
-        "@wordpress/plugins": "^7.3.0",
-        "@wordpress/preferences": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/reusable-blocks": "^5.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/server-side-render": "^5.3.0",
-        "@wordpress/url": "^4.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "@wordpress/wordcount": "^4.3.0",
-        "change-case": "^4.1.2",
-        "client-zip": "^2.4.5",
-        "clsx": "^2.1.1",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "fast-deep-equal": "^3.1.3",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "react-autosize-textarea": "^7.1.0",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/editor/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/element": {
@@ -8023,92 +5309,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-18.1.0.tgz",
-      "integrity": "sha512-5eGpXEwaZsKbEh9040nVr4ggmrpPmltP+Ie4iGruWvCme6ZIFYw70CyWEV8S102IkqjH/BaH6d+CWg8tN7sc/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/eslint-parser": "^7.16.0",
-        "@typescript-eslint/eslint-plugin": "^6.4.1",
-        "@typescript-eslint/parser": "^6.4.1",
-        "@wordpress/babel-preset-default": "^7.42.0",
-        "@wordpress/prettier-config": "^3.15.0",
-        "cosmiconfig": "^7.0.0",
-        "eslint-config-prettier": "^8.3.0",
-        "eslint-plugin-import": "^2.25.2",
-        "eslint-plugin-jest": "^27.2.3",
-        "eslint-plugin-jsdoc": "^46.4.6",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-playwright": "^0.15.3",
-        "eslint-plugin-prettier": "^5.0.0",
-        "eslint-plugin-react": "^7.27.0",
-        "eslint-plugin-react-hooks": "^4.3.0",
-        "globals": "^13.12.0",
-        "requireindex": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6.14.4"
-      },
-      "peerDependencies": {
-        "@babel/core": ">=7",
-        "eslint": ">=8",
-        "prettier": ">=3",
-        "typescript": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "prettier": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
-      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
-      "dev": true,
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.2.1",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.10.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@wordpress/eslint-plugin/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@wordpress/hooks": {
@@ -8153,522 +5353,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/icons": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.3.0.tgz",
-      "integrity": "sha512-d2jOFfLIAxPr+/Bzg7wnRDEDPogMpVefe4cHgIx9kXp/+7DG4KWNJm842qVithjs1wVgSzavzWbFrTtPEZ+Uhw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/primitives": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/icons/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/icons/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/icons/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-6.3.0.tgz",
-      "integrity": "sha512-ThMYuQL1cXWRXePe8C49V6d5oiwBBEXaF9XAp57AfduVL2Um5ZHBJ6ZXd1yWIjZ4dUWPOagWiVSGcWq1PgQYrw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/plugins": "^7.3.0",
-        "@wordpress/preferences": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/viewport": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/interface/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/is-shallow-equal": {
@@ -8716,280 +5400,6 @@
         "jest": ">=29"
       }
     },
-    "node_modules/@wordpress/keyboard-shortcuts": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-5.3.0.tgz",
-      "integrity": "sha512-Zms+SzRekXqLBW0IPxZDhusxix5xm6jBmWfOfc//uCy7xvhZS1FxEYoolfYFB7tXT7xFTQbwVYN99ICI7BeqnQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/keycodes": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/keycodes": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-3.58.0.tgz",
@@ -9003,384 +5413,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/media-utils": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-5.3.0.tgz",
-      "integrity": "sha512-OXWr5oirWs8bTRqjaFxZQYVDHQFFkvCwdTwF2pGtsw+dmvp04sU4Sye1XEsjLyiWmihQw3MxcuzrgCyoxNIrxA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^7.3.0",
-        "@wordpress/blob": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/media-utils/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/media-utils/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/media-utils/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/media-utils/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.3.0.tgz",
-      "integrity": "sha512-1aZVcmy3Aj1nn4jmdQDpVFIB7L40AkhW7maFKhEH0oo2UAiPmqJyGDeby9sD96m2hskwyZzAgI15k+KrEf17LQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/data": "^10.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/notices/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/npm-package-json-lint-config": {
       "version": "4.43.0",
       "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-4.43.0.tgz",
@@ -9391,899 +5423,6 @@
       },
       "peerDependencies": {
         "npm-package-json-lint": ">=6.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-2.3.0.tgz",
-      "integrity": "sha512-1/0RfkZ88oKbtm062ggicMyUSEy/bBpGbn4DFqgWnQbCUcNUL/A7WWWkg5rNgQcTSY4VG+2BOE5rNJQFhtsUdg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/block-editor": "^13.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/core-data": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/notices": "^5.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/url": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/patterns/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-7.3.0.tgz",
-      "integrity": "sha512-3XdjSXTUoboJSePJ/RYUmkJmi30cnCewtA0oYakszejvJpTkuL2JQsDezsJy8e4uDH3D8mhM6LkOYFLPAVvhwQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/plugins/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
@@ -10300,464 +5439,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-4.3.0.tgz",
-      "integrity": "sha512-XTPJYjdz8iy9Sy+B+RAPFwk4KkGPgjogu3mhcMvYLqqKKeVhUt6zImXVNXQbNFGTlCgB+l0b4h4L5EHmJWVDgg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/preferences/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/prettier-config": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-3.15.0.tgz",
-      "integrity": "sha512-exC2rkEioTt//AnzPRyaaFv8FNYIvamPDytNol5bKQ6Qh65QSdZZE9V+GtRCrIPL7/Bq6xba03XuRVxl9TjtJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "prettier": ">=3"
       }
     },
     "node_modules/@wordpress/primitives": {
@@ -10817,453 +5498,6 @@
         "redux": ">=4"
       }
     },
-    "node_modules/@wordpress/reusable-blocks": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-5.3.0.tgz",
-      "integrity": "sha512-D8LoreqqrwUw6OimQyLooW1oWNpVuSK8ZyJNG135lUhqzVEEGvgcofbAk03QiSqaryyjKwDyD5qmJ8G1hmG/AA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/block-editor": "^13.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/core-data": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/notices": "^5.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/url": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/rich-text": {
       "version": "6.35.0",
       "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-6.35.0.tgz",
@@ -11288,560 +5522,6 @@
         "react": "^18.0.0"
       }
     },
-    "node_modules/@wordpress/scripts": {
-      "version": "27.9.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-27.9.0.tgz",
-      "integrity": "sha512-ohiDHMnfTTBTi7qS7AVJZUi1dxwg0k3Aav1a8CzUoOE8YoT8tvMQ3W89H9XgqMgMTWUCdgTUBYLTJTivfVVbXQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.16.0",
-        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
-        "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^7.42.0",
-        "@wordpress/browserslist-config": "^5.41.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^5.9.0",
-        "@wordpress/e2e-test-utils-playwright": "^0.26.0",
-        "@wordpress/eslint-plugin": "^18.1.0",
-        "@wordpress/jest-preset-default": "^11.29.0",
-        "@wordpress/npm-package-json-lint-config": "^4.43.0",
-        "@wordpress/postcss-plugins-preset": "^4.42.0",
-        "@wordpress/prettier-config": "^3.15.0",
-        "@wordpress/stylelint-config": "^21.41.0",
-        "adm-zip": "^0.5.9",
-        "babel-jest": "^29.6.2",
-        "babel-loader": "^8.2.3",
-        "browserslist": "^4.21.10",
-        "chalk": "^4.0.0",
-        "check-node-version": "^4.1.0",
-        "clean-webpack-plugin": "^3.0.0",
-        "copy-webpack-plugin": "^10.2.0",
-        "cross-spawn": "^5.1.0",
-        "css-loader": "^6.2.0",
-        "cssnano": "^6.0.1",
-        "cwd": "^0.10.0",
-        "dir-glob": "^3.0.1",
-        "eslint": "^8.3.0",
-        "expect-puppeteer": "^4.4.0",
-        "fast-glob": "^3.2.7",
-        "filenamify": "^4.2.0",
-        "jest": "^29.6.2",
-        "jest-dev-server": "^9.0.1",
-        "jest-environment-jsdom": "^29.6.2",
-        "jest-environment-node": "^29.6.2",
-        "markdownlint-cli": "^0.31.1",
-        "merge-deep": "^3.0.3",
-        "mini-css-extract-plugin": "^2.5.1",
-        "minimist": "^1.2.0",
-        "npm-package-json-lint": "^6.4.0",
-        "npm-packlist": "^3.0.0",
-        "postcss": "^8.4.5",
-        "postcss-loader": "^6.2.1",
-        "prettier": "npm:wp-prettier@3.0.3",
-        "puppeteer-core": "^13.2.0",
-        "react-refresh": "^0.14.0",
-        "read-pkg-up": "^7.0.1",
-        "resolve-bin": "^0.4.0",
-        "rtlcss-webpack-plugin": "^4.0.7",
-        "sass": "^1.35.2",
-        "sass-loader": "^12.1.0",
-        "source-map-loader": "^3.0.0",
-        "stylelint": "^14.2.0",
-        "terser-webpack-plugin": "^5.3.9",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.88.2",
-        "webpack-bundle-analyzer": "^4.9.1",
-        "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^4.15.1"
-      },
-      "bin": {
-        "wp-scripts": "bin/wp-scripts.js"
-      },
-      "engines": {
-        "node": ">=18",
-        "npm": ">=6.14.4"
-      },
-      "peerDependencies": {
-        "@playwright/test": "^1.43.0",
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-5.3.0.tgz",
-      "integrity": "sha512-DlD0DL1/rIsLlENv68LLaDHbWH+uIJ21H+8T1QTZGYwtgdAfiNKuaadexIKfcGFq+yjGdRk0ugYWBIKMe2WuJg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/api-fetch": "^7.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/components": "^28.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/url": "^4.3.0",
-        "fast-deep-equal": "^3.1.3"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/a11y": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.3.0.tgz",
-      "integrity": "sha512-kmAE8hshmldudMhtj/RKY7lEwyux5w6zvCTbIj3a6iq0ZMhU3vsxTlCp/vEGLoYdfetwRN4zeJA9jvPki+IOUA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/components": {
-      "version": "28.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-28.3.0.tgz",
-      "integrity": "sha512-zLHtxmhbuD7j5f7wOqRu6+KYVWPRpgHsYzxOavWkkiKv0XUvWeYWBIZFM4oy6A1WJqW2nEELcAjIeBX/0UWMig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@ariakit/react": "^0.3.12",
-        "@babel/runtime": "^7.16.0",
-        "@emotion/cache": "^11.7.1",
-        "@emotion/css": "^11.7.1",
-        "@emotion/react": "^11.7.1",
-        "@emotion/serialize": "^1.0.2",
-        "@emotion/styled": "^11.6.0",
-        "@emotion/utils": "^1.0.0",
-        "@floating-ui/react-dom": "^2.0.8",
-        "@types/gradient-parser": "0.1.3",
-        "@types/highlight-words-core": "1.2.1",
-        "@use-gesture/react": "^10.3.1",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/date": "^5.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/html-entities": "^4.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/primitives": "^4.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/rich-text": "^7.3.0",
-        "@wordpress/warning": "^3.3.0",
-        "change-case": "^4.1.2",
-        "clsx": "^2.1.1",
-        "colord": "^2.7.0",
-        "date-fns": "^3.6.0",
-        "deepmerge": "^4.3.0",
-        "downshift": "^6.0.15",
-        "fast-deep-equal": "^3.1.3",
-        "framer-motion": "^11.1.9",
-        "gradient-parser": "^0.1.5",
-        "highlight-words-core": "^1.2.2",
-        "is-plain-object": "^5.0.0",
-        "memize": "^2.1.0",
-        "path-to-regexp": "^6.2.1",
-        "re-resizable": "^6.4.0",
-        "react-colorful": "^5.3.1",
-        "remove-accents": "^0.5.0",
-        "use-lilius": "^2.0.5",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/date": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.3.0.tgz",
-      "integrity": "sha512-vD0rLQxNlOoFd4n32HohhTif4P1JPW/Igjp0c/O2WZji+eXQM6P54fBu5veKvgwMmXpUn8y0xzgssj3pKAUgCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "moment": "^2.29.4",
-        "moment-timezone": "^0.5.40"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/html-entities": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.3.0.tgz",
-      "integrity": "sha512-rJDf9KjCuUnFwIwmOdN4FcL7RJnDzPxIdvvMoWXkYd9GseEeRTsY6xIG+fGgVGgYe3HwXDYSFCWTF/x2M9Eerg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/primitives": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.3.0.tgz",
-      "integrity": "sha512-h7wb2Np3n5etOg3j38GN80NEA8NgNdsSF/JJcRhpRf8FQOJd1mnKzj6szVHeKv0G7bvBif0NTgdSUm5M6Nikfg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/element": "^6.3.0",
-        "clsx": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/rich-text": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.3.0.tgz",
-      "integrity": "sha512-iL7qEybPOwtMp8WXMQndzfvT2k647ZqIMTj0rji4h2QAp/KaEHyYaIF6YhuQ7v5bSQ/9IAAOy3KGhguIuxIt8A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/a11y": "^4.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/escape-html": "^3.3.0",
-        "@wordpress/i18n": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "memize": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/server-side-render/node_modules/@wordpress/warning": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.3.0.tgz",
-      "integrity": "sha512-n82aKCxuGRNwAtSLaycErJuhKgfOc+KtiljyQITPperMh9i8bH6I+JxtYiu+aLMaY5vrVLVb+/kCzKuWVQIKPA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/shortcode": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-4.3.0.tgz",
-      "integrity": "sha512-Ononu3JfP8W/qLNeB46YuGpmqpjj+VyA9EK6pZdmf1/8Gd9Q6L2+HRyp1AEzJzs59p2pLfzvf63T90KSSZjBaQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "memize": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/style-engine": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-2.3.0.tgz",
-      "integrity": "sha512-VLnhVPDOZ32cnxFJSQbVkuF8YUd2M33m3bvw28TSvdAZcosN1WpmoEAtn9NhwU2jklvJEFfa1inlzuQ3NW/HEA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "change-case": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/stylelint-config": {
       "version": "21.41.0",
       "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-21.41.0.tgz",
@@ -11858,43 +5538,6 @@
         "stylelint": "^14.2"
       }
     },
-    "node_modules/@wordpress/sync": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-1.3.0.tgz",
-      "integrity": "sha512-up2zDx35LT3xOkx48+pfF+98p1T6q6nsZqQywf3nqbunxLBq+MYNUC7bd3z/Snn2jiCASxAINWMR5jQ1MB4Bqw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/simple-peer": "^9.11.5",
-        "@wordpress/url": "^4.3.0",
-        "import-locals": "^2.0.0",
-        "lib0": "^0.2.42",
-        "simple-peer": "^9.11.0",
-        "y-indexeddb": "~9.0.11",
-        "y-protocols": "^1.0.5",
-        "y-webrtc": "~10.2.5",
-        "yjs": "~13.6.6"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/token-list": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-3.3.0.tgz",
-      "integrity": "sha512-9IcUUebJ2KBIe371pKonpS0KtTgwDzPJBQIMkPACvw47AL3ZY83sQzBwEqAw+hNstqilOD6n/SQUhIYxzMvdhg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/undo-manager": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.18.0.tgz",
@@ -11909,295 +5552,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/@wordpress/url": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.3.0.tgz",
-      "integrity": "sha512-2rbpF2OD3rc/Jhmd4Mn9PxXTYGw63hIVMEJWzHs0x/mHmuDZEAn1vZcpDhJkksqtnHMS3BOlTv+Kbk1klxOpCg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "remove-accents": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-6.3.0.tgz",
-      "integrity": "sha512-2DCh0pSYY4zrSFvrGqGgB3tEkp/RdJhj1Lkoy52m47jIK0Q31Up+b/dJz7GpR4xmQ7Hw3ibAjGgAJj+vbSOvZw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/element": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
-        "change-case": "^4.1.2",
-        "clipboard": "^2.0.11",
-        "mousetrap": "^1.6.5",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
-        "deepmerge": "^4.3.0",
-        "equivalent-key-map": "^0.2.2",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "redux": "^4.1.2",
-        "rememo": "^4.0.2",
-        "use-memo-one": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      },
-      "peerDependencies": {
-        "redux": ">=4"
-      }
-    },
-    "node_modules/@wordpress/viewport/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
     "node_modules/@wordpress/warning": {
       "version": "2.58.0",
       "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-2.58.0.tgz",
@@ -12205,20 +5559,6 @@
       "dev": true,
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/@wordpress/wordcount": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-4.3.0.tgz",
-      "integrity": "sha512-+jTnD4XMRRxljZ6mRif5wMFqiDbIFTc/naeE2CI7mirdsnFriUD3gYmhgLsP71Rckh+9EHZpzQBCbehXU2zX1A==",
-      "dev": true,
-      "license": "GPL-2.0-or-later",
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -12839,17 +6179,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/axios": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
-      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -13066,30 +6395,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/babel-runtime": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
-      "integrity": "sha512-zeCYxDePWYAT/DfmQWIHsMSFW2vv45UIwIAMjGvQVsTd47RwsiRH0uK1yzyWZ7LDBKdhnGDPM6NYEO5CZyhPrg==",
-      "dev": true,
-      "dependencies": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.10.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-      "dev": true,
-      "hasInstallScript": true
-    },
-    "node_modules/babel-runtime/node_modules/regenerator-runtime": {
-      "version": "0.10.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha512-02YopEIhAgiBHWeoTiA8aitHDt8z6w+rQqNuIftlM+ZtvSl/brTouaU7DW6GO/cHtvxJvS4Hwv2ibKdxIRi24w==",
-      "dev": true
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -13252,6 +6557,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true
+    },
+    "node_modules/body-scroll-lock": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/body-scroll-lock/-/body-scroll-lock-3.1.5.tgz",
+      "integrity": "sha512-Yi1Xaml0EvNA0OYWxXiYNqY24AfWkbA6w5vxE7GWxtKfzIbZM+Qw+aSmkgsbWzbHiy/RCSkUZBplVxTA+E4jJg==",
       "dev": true
     },
     "node_modules/bonjour-service": {
@@ -13684,6 +6995,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true
+    },
     "node_modules/clean-webpack-plugin": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
@@ -13699,12 +7016,6 @@
       "peerDependencies": {
         "webpack": "*"
       }
-    },
-    "node_modules/client-zip": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/client-zip/-/client-zip-2.4.5.tgz",
-      "integrity": "sha512-4y4d5ZeTH/szIAMQeC8ju67pxtvj+3u20wMGwOFrZk+pegy3aSEA2JkwgC8XVDTXP/Iqn1gyqNQXmkyBp4KLEQ==",
-      "dev": true
     },
     "node_modules/clipboard": {
       "version": "2.0.11",
@@ -15013,6 +8324,12 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/dom-scroll-into-view": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/dom-scroll-into-view/-/dom-scroll-into-view-1.2.1.tgz",
+      "integrity": "sha512-LwNVg3GJOprWDO+QhLL1Z9MMgWe/KAFLxVWKzjRTxNSPn8/LLDIfmuG71YHznXCqaqTjvHJDYO1MEAgX6XCNbQ==",
+      "dev": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -19156,24 +12473,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-dev-server": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-9.0.2.tgz",
-      "integrity": "sha512-Zc/JB0IlNNrpXkhBw+h86cGrde/Mey52KvF+FER2eyrtYJTHObOwW7Iarxm3rPyTKby5+3Y2QZtl8pRz/5GCxg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "cwd": "^0.10.0",
-        "find-process": "^1.4.7",
-        "prompts": "^2.4.2",
-        "spawnd": "^9.0.2",
-        "tree-kill": "^1.2.2",
-        "wait-on": "^7.2.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
@@ -22797,6 +16096,7 @@
       "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -22986,6 +16286,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/proxy-compare": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-2.3.0.tgz",
+      "integrity": "sha512-c3L2CcAi7f7pvlD0D7xsF+2CQIW8C3HaYx2Pfgq8eA4HAl3GAH6/dVYsyBbYF/0XJs2ziGLrzmz5fmzPm6A0pQ==",
+      "dev": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -23334,6 +16640,7 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23519,6 +16826,62 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/reakit": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/reakit/-/reakit-1.3.11.tgz",
+      "integrity": "sha512-mYxw2z0fsJNOQKAEn5FJCPTU3rcrY33YZ/HzoWqZX0G7FwySp1wkCYW79WhuYMNIUFQ8s3Baob1RtsEywmZSig==",
+      "dev": true,
+      "dependencies": {
+        "@popperjs/core": "^2.5.4",
+        "body-scroll-lock": "^3.1.5",
+        "reakit-system": "^0.15.2",
+        "reakit-utils": "^0.15.2",
+        "reakit-warning": "^0.6.2"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/ariakit"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/reakit/node_modules/reakit-system": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/reakit-system/-/reakit-system-0.15.2.tgz",
+      "integrity": "sha512-TvRthEz0DmD0rcJkGamMYx+bATwnGNWJpe/lc8UV2Js8nnPvkaxrHk5fX9cVASFrWbaIyegZHCWUBfxr30bmmA==",
+      "dev": true,
+      "dependencies": {
+        "reakit-utils": "^0.15.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/reakit/node_modules/reakit-utils": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
+      "integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/reakit/node_modules/reakit-warning": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/reakit-warning/-/reakit-warning-0.6.2.tgz",
+      "integrity": "sha512-z/3fvuc46DJyD3nJAUOto6inz2EbSQTjvI/KBQDqxwB0y02HDyeP8IWOJxvkuAUGkWpeSx+H3QWQFSNiPcHtmw==",
+      "dev": true,
+      "dependencies": {
+        "reakit-utils": "^0.15.2"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
       }
     },
     "node_modules/rechoir": {
@@ -23835,77 +17198,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/rtlcss": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-3.5.0.tgz",
-      "integrity": "sha512-wzgMaMFHQTnyi9YOwsx9LjOxYXJPzS8sYnFaKm6R5ysvTkwzHiB0vxnbHwchHQT65PTdBjDG21/kQBWI7q9O7A==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^5.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.3.11",
-        "strip-json-comments": "^3.1.1"
-      },
-      "bin": {
-        "rtlcss": "bin/rtlcss.js"
-      }
-    },
-    "node_modules/rtlcss-webpack-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/rtlcss-webpack-plugin/-/rtlcss-webpack-plugin-4.0.7.tgz",
-      "integrity": "sha512-ouSbJtgcLBBQIsMgarxsDnfgRqm/AS4BKls/mz/Xb6HSl+PdEzefTR+Wz5uWQx4odoX0g261Z7yb3QBz0MTm0g==",
-      "dev": true,
-      "dependencies": {
-        "babel-runtime": "~6.25.0",
-        "rtlcss": "^3.5.0"
-      }
-    },
-    "node_modules/rtlcss/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rtlcss/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/rtlcss/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-con": {
@@ -24963,31 +18255,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/spawnd": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-9.0.2.tgz",
-      "integrity": "sha512-nl8DVHEDQ57IcKakzpjanspVChkMpGLuVwMR/eOn9cXE55Qr6luD2Kn06sA0ootRMdgrU4tInN6lA6ohTNvysw==",
-      "dev": true,
-      "dependencies": {
-        "signal-exit": "^4.1.0",
-        "tree-kill": "^1.2.2"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/spawnd/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -26005,6 +19272,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.9.tgz",
+      "integrity": "sha512-7bBrcF+/LQzSgFmT0X5YclVqQxtv7TDJ1f8Wj7ibBu/U6BMLeOpUxuZjV7rMc44UtKxlnMFigdhFAIszSX1DMg==",
+      "dev": true,
+      "dependencies": {
+        "gopd": "^1.0.1",
+        "typedarray.prototype.slice": "^1.0.3",
+        "which-typed-array": "^1.1.15"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/tree-kill": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
@@ -26134,6 +19418,12 @@
         "turbo-windows-64": "2.0.7",
         "turbo-windows-arm64": "2.0.7"
       }
+    },
+    "node_modules/turbo-combine-reducers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/turbo-combine-reducers/-/turbo-combine-reducers-1.0.2.tgz",
+      "integrity": "sha512-gHbdMZlA6Ym6Ur5pSH/UWrNQMIM9IqTH6SoL1DbHpqEdQ8i+cFunSmSlFykPt0eGQwZ4d/XTHOl74H0/kFBVWw==",
+      "dev": true
     },
     "node_modules/turbo-darwin-64": {
       "version": "2.0.7",
@@ -26378,6 +19668,26 @@
       "dev": true,
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typedarray.prototype.slice": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typedarray.prototype.slice/-/typedarray.prototype.slice-1.0.3.tgz",
+      "integrity": "sha512-8WbVAQAUlENo1q3c3zZYuy5k9VzBQvp8AX9WOtbvyWlLM1v5JaSRmjubLjzHF4JFtptjH/5c/i95yaElvcjC0A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.0",
+        "es-errors": "^1.3.0",
+        "typed-array-buffer": "^1.0.2",
+        "typed-array-byte-offset": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/typescript": {
@@ -26802,6 +20112,56 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/valtio": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/valtio/-/valtio-1.7.0.tgz",
+      "integrity": "sha512-3Tnix66EERwMcrl1rfB3ylcewOcL5L/GiPmC3FlVNreQzqf2jufEeqlNmgnLgSGchkEmH3WYVtS+x6Qw4r+yzQ==",
+      "dev": true,
+      "dependencies": {
+        "proxy-compare": "2.3.0",
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@babel/helper-module-imports": ">=7.12",
+        "@babel/types": ">=7.13",
+        "aslemammad-vite-plugin-macro": ">=1.0.0-alpha.1",
+        "babel-plugin-macros": ">=3.0",
+        "react": ">=16.8",
+        "vite": ">=2.8.6"
+      },
+      "peerDependenciesMeta": {
+        "@babel/helper-module-imports": {
+          "optional": true
+        },
+        "@babel/types": {
+          "optional": true
+        },
+        "aslemammad-vite-plugin-macro": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/valtio/node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "dev": true,
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -26821,25 +20181,6 @@
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/wait-on": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-7.2.0.tgz",
-      "integrity": "sha512-wCQcHkRazgjG5XoAq9jbTMLpNIjoSlZslrJ2+N9MxDsGEv1HnFoVjOCexL0ESva7Y9cu350j+DWADdk54s4AFQ==",
-      "dev": true,
-      "dependencies": {
-        "axios": "^1.6.1",
-        "joi": "^17.11.0",
-        "lodash": "^4.17.21",
-        "minimist": "^1.2.8",
-        "rxjs": "^7.8.1"
-      },
-      "bin": {
-        "wait-on": "bin/wait-on"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/walker": {
@@ -26872,12 +20213,6 @@
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "node_modules/web-vitals": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-3.5.2.tgz",
-      "integrity": "sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==",
-      "dev": true
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -27711,13 +21046,1419 @@
         "@jest/globals": "^29.7.0",
         "@testing-library/react": "^16.0.0",
         "@types/wordpress__block-editor": "^11.5.15",
-        "@wordpress/dom-ready": "^4.3.0",
-        "@wordpress/editor": "^14.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/interface": "^6.3.0",
-        "@wordpress/scripts": "^27.8.0",
+        "@wordpress/dom-ready": "^3.42.13",
+        "@wordpress/editor": "^13.19.14",
+        "@wordpress/icons": "^9.33.13",
+        "@wordpress/interface": "^5.19.14",
+        "@wordpress/scripts": "^26.13.13",
         "react": "^18.2.0",
         "type-coverage": "^2.29.1"
+      }
+    },
+    "packages/iconography/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "packages/iconography/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "dev": true,
+      "optional": true
+    },
+    "packages/iconography/node_modules/@webpack-cli/configtest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "packages/iconography/node_modules/@webpack-cli/info": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "packages/iconography/node_modules/@webpack-cli/serve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/block-editor": {
+      "version": "12.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.26.0.tgz",
+      "integrity": "sha512-wkBP37hB6Fb1AaUIjry6S3LlFrjnVq3Seg8ktZPLozDv2cyODs/ym8+wjv8TR/aiuSWdk0dZZywYMNc+vHEfEg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "@react-spring/web": "^9.4.5",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/api-fetch": "^6.55.0",
+        "@wordpress/blob": "^3.58.0",
+        "@wordpress/blocks": "^12.35.0",
+        "@wordpress/commands": "^0.29.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/date": "^4.58.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/escape-html": "^2.58.0",
+        "@wordpress/hooks": "^3.58.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keyboard-shortcuts": "^4.35.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/notices": "^4.26.0",
+        "@wordpress/preferences": "^3.35.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/rich-text": "^6.35.0",
+        "@wordpress/style-engine": "^1.41.0",
+        "@wordpress/token-list": "^2.58.0",
+        "@wordpress/url": "^3.59.0",
+        "@wordpress/warning": "^2.58.0",
+        "@wordpress/wordcount": "^3.58.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "deepmerge": "^4.3.0",
+        "diff": "^4.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "memize": "^2.1.0",
+        "postcss": "^8.4.21",
+        "postcss-prefixwrap": "^1.41.0",
+        "postcss-urlrebase": "^1.0.0",
+        "react-autosize-textarea": "^7.1.0",
+        "react-easy-crop": "^5.0.6",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/block-editor/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/blocks": {
+      "version": "12.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.35.0.tgz",
+      "integrity": "sha512-BwjMca4aGuttu3C0nLLpt6MBg6IBCogA6ulGTyg+0YdKnwac52k+2wfersqAem8AFgG0hTDwrIpLsWLxpF9dtg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.58.0",
+        "@wordpress/blob": "^3.58.0",
+        "@wordpress/block-serialization-default-parser": "^4.58.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/hooks": "^3.58.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/rich-text": "^6.35.0",
+        "@wordpress/shortcode": "^3.58.0",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "fast-deep-equal": "^3.1.3",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "react-is": "^18.3.0",
+        "remove-accents": "^0.5.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/commands": {
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-0.29.0.tgz",
+      "integrity": "sha512-HqTrYfQw/5cdT2hPgmuKW6gugnt1Pqtg9zjRHUa+D4ME7mjR4dYQoHRgnFM+hm8OOuEZRVBsa1kYO3t3041Jew==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/keyboard-shortcuts": "^4.35.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "clsx": "^2.1.1",
+        "cmdk": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/commands/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/core-data": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-6.35.0.tgz",
+      "integrity": "sha512-VnESF55nkAkKHQVwj0Oo8AU6w/yWjg/RQb+wKqJRnDuHEKHDAF5PI+9lYmcAsbXdnAc2yyf3lwBGk4w8m4uxlA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/api-fetch": "^6.55.0",
+        "@wordpress/block-editor": "^12.26.0",
+        "@wordpress/blocks": "^12.35.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/rich-text": "^6.35.0",
+        "@wordpress/sync": "^0.20.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "@wordpress/url": "^3.59.0",
+        "change-case": "^4.1.2",
+        "equivalent-key-map": "^0.2.2",
+        "fast-deep-equal": "^3.1.3",
+        "memize": "^2.1.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/dependency-extraction-webpack-plugin": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.31.0.tgz",
+      "integrity": "sha512-Xpm8EEhi6e8GL1juYh/70AFbcE/ZVXJ3p47KMkkEsn5t+hG9QHjKe2lTj98v2r3rB+ampoK+whdV1w6gItXYpw==",
+      "dev": true,
+      "dependencies": {
+        "json2php": "^0.0.7",
+        "webpack-sources": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "webpack": "^4.8.3 || ^5.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/dom-ready": {
+      "version": "3.42.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-3.42.13.tgz",
+      "integrity": "sha512-mtqstqT1YFfIGl8rQipG9d8UwvGIZUP4Y8E1Tq3V9CAMV6ChJEYCZIGs/asHjqJSebNnXEWUEzQKAbPnIhnW3Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/e2e-test-utils-playwright": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.10.13.tgz",
+      "integrity": "sha512-5zqIsG6Nn6N0DBlK9GyvYKxUrK7dEBHFInRnIqqfimWAQmz07iBCJU34njs9lQi+/GzKfXS+2XgBI7dDQnbfwQ==",
+      "dev": true,
+      "dependencies": {
+        "@wordpress/api-fetch": "^6.39.13",
+        "@wordpress/keycodes": "^3.42.13",
+        "@wordpress/url": "^3.43.13",
+        "change-case": "^4.1.2",
+        "form-data": "^4.0.0",
+        "get-port": "^5.1.1",
+        "lighthouse": "^10.4.0",
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/editor": {
+      "version": "13.19.14",
+      "resolved": "https://registry.npmjs.org/@wordpress/editor/-/editor-13.19.14.tgz",
+      "integrity": "sha512-t1RFJl0Bf+qJpBHtiUl0qoxJjpNNGcpSZLejnhR97+i32l/4ewg8+z69zwFtW4ChNQjLnAFnpQZ5pT/CqkkKpQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.42.13",
+        "@wordpress/api-fetch": "^6.39.13",
+        "@wordpress/blob": "^3.42.13",
+        "@wordpress/block-editor": "^12.10.14",
+        "@wordpress/blocks": "^12.19.13",
+        "@wordpress/components": "^25.8.14",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/core-data": "^6.19.14",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/date": "^4.42.13",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/dom": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/hooks": "^3.42.13",
+        "@wordpress/html-entities": "^3.42.13",
+        "@wordpress/i18n": "^4.42.13",
+        "@wordpress/icons": "^9.33.13",
+        "@wordpress/keyboard-shortcuts": "^4.19.13",
+        "@wordpress/keycodes": "^3.42.13",
+        "@wordpress/media-utils": "^4.33.13",
+        "@wordpress/notices": "^4.10.13",
+        "@wordpress/patterns": "^1.3.14",
+        "@wordpress/preferences": "^3.19.14",
+        "@wordpress/private-apis": "^0.24.13",
+        "@wordpress/reusable-blocks": "^4.19.14",
+        "@wordpress/rich-text": "^6.19.13",
+        "@wordpress/server-side-render": "^4.19.14",
+        "@wordpress/url": "^3.43.13",
+        "@wordpress/wordcount": "^3.42.13",
+        "classnames": "^2.3.1",
+        "date-fns": "^2.28.0",
+        "memize": "^2.1.0",
+        "react-autosize-textarea": "^7.1.0",
+        "rememo": "^4.0.2",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/editor/node_modules/@wordpress/components": {
+      "version": "25.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.16.0.tgz",
+      "integrity": "sha512-voQuMsO5JbH+JW33TnWurwwvpSb8IQ4XU5wyVMubX4TUwadt+/2ToNJbZIDXoaJPei7vbM81Ft+pH+zGlN8CyA==",
+      "dev": true,
+      "dependencies": {
+        "@ariakit/react": "^0.3.12",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.1",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.2.24",
+        "@wordpress/a11y": "^3.50.0",
+        "@wordpress/compose": "^6.27.0",
+        "@wordpress/date": "^4.50.0",
+        "@wordpress/deprecated": "^3.50.0",
+        "@wordpress/dom": "^3.50.0",
+        "@wordpress/element": "^5.27.0",
+        "@wordpress/escape-html": "^2.50.0",
+        "@wordpress/hooks": "^3.50.0",
+        "@wordpress/html-entities": "^3.50.0",
+        "@wordpress/i18n": "^4.50.0",
+        "@wordpress/icons": "^9.41.0",
+        "@wordpress/is-shallow-equal": "^4.50.0",
+        "@wordpress/keycodes": "^3.50.0",
+        "@wordpress/primitives": "^3.48.0",
+        "@wordpress/private-apis": "^0.32.0",
+        "@wordpress/rich-text": "^6.27.0",
+        "@wordpress/warning": "^2.50.0",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "date-fns": "^2.28.0",
+        "deepmerge": "^4.3.0",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^10.13.0",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "reakit": "^1.3.11",
+        "remove-accents": "^0.5.0",
+        "use-lilius": "^2.0.1",
+        "uuid": "^9.0.1",
+        "valtio": "1.7.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/editor/node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.32.0.tgz",
+      "integrity": "sha512-P7nxI/bGMDQhtlTfSe1Y2SDfrd20K5UMnTHbq+hmIkzBGRpNPbdGeNu2bZaZtIvmXk1OCR0Fkef+e6QqkOfYPg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/editor/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/editor/node_modules/@wordpress/private-apis": {
+      "version": "0.24.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.24.13.tgz",
+      "integrity": "sha512-RgvGB6VQpPnEGU8Y61tzpgPFYDRAW28+2gcdOXYiqSVdZfGBL6+hBs5bMbLSJYRU9G5pl5q4Eb0lHlkMgHW5FA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/eslint-plugin": {
+      "version": "16.0.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-16.0.13.tgz",
+      "integrity": "sha512-Qk5Y7ifT0lfOOx5RQrEGa/DSw01CP+D2bCKr20SXLt3KDstViBlqjBiI1Yxv7EeS+AvaNbQO5M8Mm4B5mUB3kQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/eslint-parser": "^7.16.0",
+        "@typescript-eslint/eslint-plugin": "^6.4.1",
+        "@typescript-eslint/parser": "^6.4.1",
+        "@wordpress/babel-preset-default": "^7.26.13",
+        "@wordpress/prettier-config": "^2.25.13",
+        "cosmiconfig": "^7.0.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-jest": "^27.2.3",
+        "eslint-plugin-jsdoc": "^46.4.6",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-playwright": "^0.15.3",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-react": "^7.27.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "globals": "^13.12.0",
+        "requireindex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.14.4"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7",
+        "eslint": ">=8",
+        "prettier": ">=2",
+        "typescript": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/icons": {
+      "version": "9.33.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.33.13.tgz",
+      "integrity": "sha512-4M34sMRIlyL7a3CDRI7rAfysZQm2VW1ptB4aGDf5tVMXd//hCRkj/OGE++AYkTYQNckli9uqhTkv2xoOOw1F6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/primitives": "^3.40.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/interface": {
+      "version": "5.19.14",
+      "resolved": "https://registry.npmjs.org/@wordpress/interface/-/interface-5.19.14.tgz",
+      "integrity": "sha512-WsIsSKJuhAcXD3YbmUoncL1JZ6hKAJXs7Lb/bjrOJxCts/YOy5yMF3/I05r8f1Tfw/pS8wlHMRjIXH/gvnvWVA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.42.13",
+        "@wordpress/components": "^25.8.14",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/i18n": "^4.42.13",
+        "@wordpress/icons": "^9.33.13",
+        "@wordpress/plugins": "^6.10.14",
+        "@wordpress/preferences": "^3.19.14",
+        "@wordpress/viewport": "^5.19.13",
+        "classnames": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/interface/node_modules/@wordpress/components": {
+      "version": "25.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.16.0.tgz",
+      "integrity": "sha512-voQuMsO5JbH+JW33TnWurwwvpSb8IQ4XU5wyVMubX4TUwadt+/2ToNJbZIDXoaJPei7vbM81Ft+pH+zGlN8CyA==",
+      "dev": true,
+      "dependencies": {
+        "@ariakit/react": "^0.3.12",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.1",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.2.24",
+        "@wordpress/a11y": "^3.50.0",
+        "@wordpress/compose": "^6.27.0",
+        "@wordpress/date": "^4.50.0",
+        "@wordpress/deprecated": "^3.50.0",
+        "@wordpress/dom": "^3.50.0",
+        "@wordpress/element": "^5.27.0",
+        "@wordpress/escape-html": "^2.50.0",
+        "@wordpress/hooks": "^3.50.0",
+        "@wordpress/html-entities": "^3.50.0",
+        "@wordpress/i18n": "^4.50.0",
+        "@wordpress/icons": "^9.41.0",
+        "@wordpress/is-shallow-equal": "^4.50.0",
+        "@wordpress/keycodes": "^3.50.0",
+        "@wordpress/primitives": "^3.48.0",
+        "@wordpress/private-apis": "^0.32.0",
+        "@wordpress/rich-text": "^6.27.0",
+        "@wordpress/warning": "^2.50.0",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "date-fns": "^2.28.0",
+        "deepmerge": "^4.3.0",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^10.13.0",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "reakit": "^1.3.11",
+        "remove-accents": "^0.5.0",
+        "use-lilius": "^2.0.1",
+        "uuid": "^9.0.1",
+        "valtio": "1.7.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/interface/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/interface/node_modules/@wordpress/private-apis": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.32.0.tgz",
+      "integrity": "sha512-P7nxI/bGMDQhtlTfSe1Y2SDfrd20K5UMnTHbq+hmIkzBGRpNPbdGeNu2bZaZtIvmXk1OCR0Fkef+e6QqkOfYPg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.35.0.tgz",
+      "integrity": "sha512-DR+fWhHt67GQT6PlrfMBpSmEYNCep+XvMYA55cnxoQ80LIFN5N5bkr4VeYdbrSatuOSRACm+6cfoQSIMQbdmjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/keycodes": "^3.58.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/media-utils": {
+      "version": "4.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/media-utils/-/media-utils-4.49.0.tgz",
+      "integrity": "sha512-6xfkK3ehy2siAvQXnF9ZiEiPJHmQr6tOlwnFML7dSrnNzOyWxprTxvsdXMP51O2r/kLozdc/gr60fnQAMs70vw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/api-fetch": "^6.55.0",
+        "@wordpress/blob": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/i18n": "^4.58.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/notices": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.26.0.tgz",
+      "integrity": "sha512-Lu98xQdtZHgC3d32IFalZbOiIu8aRFWlEQXXfRutD7EhXXp6FIXvnvc054700/Dk1mg9P/bWd0zm/cigkXgfkA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/data": "^9.28.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/patterns": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/patterns/-/patterns-1.19.0.tgz",
+      "integrity": "sha512-L0NhNn6P2YuZRgZNlZP0IFYKoVjQI5Vf/4edgG8yjYwuXLkanJvBZWglswu4Z8jzlsBN72o0n3K37FO8VzcnmA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/block-editor": "^12.26.0",
+        "@wordpress/blocks": "^12.35.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/core-data": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/notices": "^4.26.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/patterns/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/plugins": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/plugins/-/plugins-6.26.0.tgz",
+      "integrity": "sha512-GsV9mSlHF+Tn3BHCLR+nM+7FmyWDOcxHHSBwHUVNbghrmLM4Hy/Jvs8vcirTZivGEbQSB6EBJO7QIFRrXk0PpQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/hooks": "^3.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/plugins/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/preferences": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.35.0.tgz",
+      "integrity": "sha512-OFzSEiI8Kk5YJtyPFnAauRHXtjuTJHkWapvcagpMoTP0WvwBwGfr5AeIIgV2ONtA3edrfMGgmrJUK7pd61K/1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/prettier-config": {
+      "version": "2.25.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.25.13.tgz",
+      "integrity": "sha512-iz58o0X91E24j0VFtzwn5qG84w+s4VlRCuZWa/lPL6pfGtOSw30c60wCrYKCA1IWIIAWdpRAYfEh7errPyKiPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": ">=2"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/reusable-blocks": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/reusable-blocks/-/reusable-blocks-4.35.0.tgz",
+      "integrity": "sha512-vofZGdVCOljSviar11sJWK+8loVAz53fBqPllcC0MbnSWkj4VPF4L6VWFVus1PQyL2MdkHynWRce9MHpKvN1NQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/block-editor": "^12.26.0",
+        "@wordpress/blocks": "^12.35.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/core-data": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/notices": "^4.26.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/reusable-blocks/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/scripts": {
+      "version": "26.13.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.13.13.tgz",
+      "integrity": "sha512-G2K56PmjRPI0ddgmrnopp3AVMLACqfrFvz+NyGbYCPWQoYL3xnphrS+w3uPwuxcuBtgR34yr+xCvrMnJsY3Wag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
+        "@svgr/webpack": "^8.0.1",
+        "@wordpress/babel-preset-default": "^7.26.13",
+        "@wordpress/browserslist-config": "^5.25.13",
+        "@wordpress/dependency-extraction-webpack-plugin": "^4.25.13",
+        "@wordpress/e2e-test-utils-playwright": "^0.10.13",
+        "@wordpress/eslint-plugin": "^16.0.13",
+        "@wordpress/jest-preset-default": "^11.13.13",
+        "@wordpress/npm-package-json-lint-config": "^4.27.13",
+        "@wordpress/postcss-plugins-preset": "^4.26.13",
+        "@wordpress/prettier-config": "^2.25.13",
+        "@wordpress/stylelint-config": "^21.25.13",
+        "adm-zip": "^0.5.9",
+        "babel-jest": "^29.6.2",
+        "babel-loader": "^8.2.3",
+        "browserslist": "^4.21.9",
+        "chalk": "^4.0.0",
+        "check-node-version": "^4.1.0",
+        "clean-webpack-plugin": "^3.0.0",
+        "copy-webpack-plugin": "^10.2.0",
+        "cross-spawn": "^5.1.0",
+        "css-loader": "^6.2.0",
+        "cssnano": "^6.0.1",
+        "cwd": "^0.10.0",
+        "dir-glob": "^3.0.1",
+        "eslint": "^8.3.0",
+        "expect-puppeteer": "^4.4.0",
+        "fast-glob": "^3.2.7",
+        "filenamify": "^4.2.0",
+        "jest": "^29.6.2",
+        "jest-dev-server": "^6.0.2",
+        "jest-environment-jsdom": "^29.6.2",
+        "jest-environment-node": "^29.6.2",
+        "markdownlint-cli": "^0.31.1",
+        "merge-deep": "^3.0.3",
+        "mini-css-extract-plugin": "^2.5.1",
+        "minimist": "^1.2.0",
+        "npm-package-json-lint": "^6.4.0",
+        "npm-packlist": "^3.0.0",
+        "playwright-core": "1.32.0",
+        "postcss": "^8.4.5",
+        "postcss-loader": "^6.2.1",
+        "prettier": "npm:wp-prettier@3.0.3-beta-3",
+        "puppeteer-core": "^13.2.0",
+        "react-refresh": "^0.10.0",
+        "read-pkg-up": "^7.0.1",
+        "resolve-bin": "^0.4.0",
+        "sass": "^1.35.2",
+        "sass-loader": "^12.1.0",
+        "source-map-loader": "^3.0.0",
+        "stylelint": "^14.2.0",
+        "terser-webpack-plugin": "^5.3.9",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.47.1",
+        "webpack-bundle-analyzer": "^4.4.2",
+        "webpack-cli": "^4.9.1",
+        "webpack-dev-server": "^4.4.0"
+      },
+      "bin": {
+        "wp-scripts": "bin/wp-scripts.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.14.4"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.32.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/scripts/node_modules/prettier": {
+      "name": "wp-prettier",
+      "version": "3.0.3-beta-3",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3-beta-3.tgz",
+      "integrity": "sha512-R3+TD7j0rnqEpMgylrUrHdi1W6ypwh4QGeFOZQ9YjP9WvNnZzBAS71yry1h7xIcG/bVaNKBCoWNqbqJY6vkOKQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/server-side-render": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/server-side-render/-/server-side-render-4.35.0.tgz",
+      "integrity": "sha512-yTbq31iGFc9VaRMtdCLlyZtbwCN+WdiECEqY6MsMXf31/TDmUcdZPxRTORy3Rz2HxEpFfUMjpRz7A8wn1QZmzA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/api-fetch": "^6.55.0",
+        "@wordpress/blocks": "^12.35.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/style-engine": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.41.0.tgz",
+      "integrity": "sha512-aM5bbJn6m8SHRotCoh/fSGuIB0MQJoVFBjpzIDoUDQ1KlO7CbY+fj9daDV1FZPMNv0h0ZEFWZ+y7Gv/CERypMA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/sync": {
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-0.20.0.tgz",
+      "integrity": "sha512-nEB2UHiSF0PoU5irAmeuljt4OQbqKHpOlJOb0WMiydbDBGTzquxF6I61ax2mFTbSDntL0AUt8pxi6eT9con1sQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/simple-peer": "^9.11.5",
+        "@wordpress/url": "^3.59.0",
+        "import-locals": "^2.0.0",
+        "lib0": "^0.2.42",
+        "simple-peer": "^9.11.0",
+        "y-indexeddb": "~9.0.11",
+        "y-protocols": "^1.0.5",
+        "y-webrtc": "~10.2.5",
+        "yjs": "~13.6.6"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/token-list": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.58.0.tgz",
+      "integrity": "sha512-xzNGzAZ87GERq7rZvZjMv742nj37tSLFBb8+c7oaLdpUpfn8YTaXQacvphdN2jmtfHvEZHivW7hErwqF9eQW/A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/viewport": {
+      "version": "5.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/viewport/-/viewport-5.35.0.tgz",
+      "integrity": "sha512-iCIVbFcA1CzGXEVu5COoi6DRdh3m3zEMWOYKKqF1C7W/LhZnTNRsHOZbHq0tv7MOkwx0Nl7+hDJlPRM0B3fb7A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/element": "^5.35.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/iconography/node_modules/@wordpress/wordcount": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.58.0.tgz",
+      "integrity": "sha512-cxmOOh8d4VeIC3B9HcqhlTQePmNkNrPeHQLj6xWHfC0Elflj+kYAjsTwkjVQ3tBMC4+mQzva1O8tFSVh02gs7w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/iconography/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "packages/iconography/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/iconography/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/iconography/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "packages/iconography/node_modules/framer-motion": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
+      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/iconography/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/iconography/node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "packages/iconography/node_modules/jest-dev-server": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-6.2.0.tgz",
+      "integrity": "sha512-ZWh8CuvxwjhYfvw4tGeftziqIvw/26R6AG3OTgNTQeXul8aZz48RQjDpnlDwnWX53jxJJl9fcigqIdSU5lYZuw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "cwd": "^0.10.0",
+        "find-process": "^1.4.7",
+        "prompts": "^2.4.2",
+        "spawnd": "^6.2.0",
+        "tree-kill": "^1.2.2",
+        "wait-on": "^6.0.1"
+      }
+    },
+    "packages/iconography/node_modules/playwright-core": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+      "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/iconography/node_modules/react-refresh": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
+      "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/iconography/node_modules/rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "packages/iconography/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/iconography/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/iconography/node_modules/spawnd": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.2.0.tgz",
+      "integrity": "sha512-qX/I4lQy4KgVEcNle0kuc4FxFWHISzBhZW1YemPfwmrmQjyZmfTK/OhBKkhrD2ooAaFZEm1maEBLE6/6enwt+g==",
+      "dev": true,
+      "dependencies": {
+        "exit": "^0.1.2",
+        "signal-exit": "^3.0.7",
+        "tree-kill": "^1.2.2"
+      }
+    },
+    "packages/iconography/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/iconography/node_modules/wait-on": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
+      "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.25.0",
+        "joi": "^17.6.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.5",
+        "rxjs": "^7.5.4"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/iconography/node_modules/webpack-cli": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.2.0",
+        "@webpack-cli/info": "^1.5.0",
+        "@webpack-cli/serve": "^1.7.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "cross-spawn": "^7.0.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "packages/iconography/node_modules/webpack-cli/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "packages/iconography/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "packages/query-include-exclude": {
@@ -27727,60 +22468,725 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@testing-library/react": "^16.0.0",
-        "@wordpress/block-editor": "^13.3.0",
-        "@wordpress/blocks": "^13.3.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/core-data": "^7.3.0",
-        "@wordpress/data": "^10.3.0",
-        "@wordpress/hooks": "^4.3.0",
-        "@wordpress/icons": "^10.3.0",
-        "@wordpress/scripts": "^27.8.0",
+        "@wordpress/block-editor": "^12.10.14",
+        "@wordpress/blocks": "^12.19.13",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/core-data": "^6.19.14",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/hooks": "^3.42.13",
+        "@wordpress/icons": "^9.33.13",
+        "@wordpress/scripts": "^26.13.13",
         "react": "^18.2.0",
         "type-coverage": "^2.29.1"
       }
     },
-    "packages/query-include-exclude/node_modules/@wordpress/compose": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-7.3.0.tgz",
-      "integrity": "sha512-TtAYdKnqQ/L/nF0+fmlQ1wAvm90X9HRBrAuEMNmkzKhews/5GR0rR3dNSMjlf7C6mNdTO3mkYt6AQf9fvZFoiQ==",
+    "packages/query-include-exclude/node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "dev": true,
+      "optional": true
+    },
+    "packages/query-include-exclude/node_modules/@webpack-cli/configtest": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+      "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x",
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@webpack-cli/info": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+      "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+      "dev": true,
+      "dependencies": {
+        "envinfo": "^7.7.3"
+      },
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@webpack-cli/serve": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+      "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+      "dev": true,
+      "peerDependencies": {
+        "webpack-cli": "4.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/api-fetch": {
+      "version": "6.55.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-6.55.0.tgz",
+      "integrity": "sha512-1HrCUsJdeRY5Y0IjplotINwqMRO81e7O7VhBScuKk7iOuDm/E1ioKv2uLGnPNWziYu+Zf025byxOqVzXDyM2gw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/url": "^3.59.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/autop": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/autop/-/autop-3.58.0.tgz",
+      "integrity": "sha512-RsdUV57A+DTJGU3slq/S9vTOtVkatnT1YyGIK3UDKaEhXkvBPtLTWwd3WR13GCfjFZ5XupH9FAGUQFkOve0eKQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/blob": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/blob/-/blob-3.58.0.tgz",
+      "integrity": "sha512-6L3WqbOWEGFOSs3vLMwJ83YScggCiJ9NvZj1kC7mgeiP302UP2Fxkt4KlfjeTsD350XcvakkD/57wRkHXd819Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/block-editor": {
+      "version": "12.10.14",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-editor/-/block-editor-12.10.14.tgz",
+      "integrity": "sha512-x56FPZZfJPk/Vd1aKIdpBIllrUuAVgwom+mYH0OohCmUzCBp1Eg8Urg5nshZpiLXpHt2dXycQCLu2Mpb+YpOJw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@emotion/react": "^11.7.1",
+        "@emotion/styled": "^11.6.0",
+        "@react-spring/web": "^9.4.5",
+        "@wordpress/a11y": "^3.42.13",
+        "@wordpress/api-fetch": "^6.39.13",
+        "@wordpress/blob": "^3.42.13",
+        "@wordpress/blocks": "^12.19.13",
+        "@wordpress/commands": "^0.13.14",
+        "@wordpress/components": "^25.8.14",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/date": "^4.42.13",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/dom": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/escape-html": "^2.42.13",
+        "@wordpress/hooks": "^3.42.13",
+        "@wordpress/html-entities": "^3.42.13",
+        "@wordpress/i18n": "^4.42.13",
+        "@wordpress/icons": "^9.33.13",
+        "@wordpress/is-shallow-equal": "^4.42.13",
+        "@wordpress/keyboard-shortcuts": "^4.19.13",
+        "@wordpress/keycodes": "^3.42.13",
+        "@wordpress/notices": "^4.10.13",
+        "@wordpress/preferences": "^3.19.14",
+        "@wordpress/private-apis": "^0.24.13",
+        "@wordpress/rich-text": "^6.19.13",
+        "@wordpress/shortcode": "^3.42.13",
+        "@wordpress/style-engine": "^1.25.13",
+        "@wordpress/token-list": "^2.42.13",
+        "@wordpress/url": "^3.43.13",
+        "@wordpress/warning": "^2.42.13",
+        "@wordpress/wordcount": "^3.42.13",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "deepmerge": "^4.3.0",
+        "diff": "^4.0.2",
+        "dom-scroll-into-view": "^1.2.1",
+        "fast-deep-equal": "^3.1.3",
+        "inherits": "^2.0.3",
+        "react-autosize-textarea": "^7.1.0",
+        "react-easy-crop": "^4.5.1",
+        "rememo": "^4.0.2",
+        "remove-accents": "^0.5.0",
+        "traverse": "^0.6.6"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/block-editor/node_modules/@wordpress/private-apis": {
+      "version": "0.24.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.24.13.tgz",
+      "integrity": "sha512-RgvGB6VQpPnEGU8Y61tzpgPFYDRAW28+2gcdOXYiqSVdZfGBL6+hBs5bMbLSJYRU9G5pl5q4Eb0lHlkMgHW5FA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/block-serialization-default-parser": {
+      "version": "4.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/block-serialization-default-parser/-/block-serialization-default-parser-4.58.0.tgz",
+      "integrity": "sha512-++fowmFEJC+1SwiCGuLPO9k+g3rgI2SCAA/p8/Bc1rNgnKB+rowzmQvSIIlRpcUkmOxHOrH5uruOEX27Ksg6uw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/blocks": {
+      "version": "12.19.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/blocks/-/blocks-12.19.13.tgz",
+      "integrity": "sha512-KdNcYb5Cr4sgzOkJM+KpPZeLLFr8e06CkRDp0EQk7VGSsoScXpqIcMEtMcKNQp1XPuJ6npMr/BacC5qNjyHA1A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/autop": "^3.42.13",
+        "@wordpress/blob": "^3.42.13",
+        "@wordpress/block-serialization-default-parser": "^4.42.13",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/dom": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/hooks": "^3.42.13",
+        "@wordpress/html-entities": "^3.42.13",
+        "@wordpress/i18n": "^4.42.13",
+        "@wordpress/is-shallow-equal": "^4.42.13",
+        "@wordpress/private-apis": "^0.24.13",
+        "@wordpress/shortcode": "^3.42.13",
+        "change-case": "^4.1.2",
+        "colord": "^2.7.0",
+        "deepmerge": "^4.3.0",
+        "fast-deep-equal": "^3.1.3",
+        "hpq": "^1.3.0",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "rememo": "^4.0.2",
+        "remove-accents": "^0.5.0",
+        "showdown": "^1.9.1",
+        "simple-html-tokenizer": "^0.5.7",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/blocks/node_modules/@wordpress/private-apis": {
+      "version": "0.24.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.24.13.tgz",
+      "integrity": "sha512-RgvGB6VQpPnEGU8Y61tzpgPFYDRAW28+2gcdOXYiqSVdZfGBL6+hBs5bMbLSJYRU9G5pl5q4Eb0lHlkMgHW5FA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/commands": {
+      "version": "0.13.14",
+      "resolved": "https://registry.npmjs.org/@wordpress/commands/-/commands-0.13.14.tgz",
+      "integrity": "sha512-aSOuRbsr+YYFvRbkXaubHdlAtf/xpG1mUWXEw9VMWCag77hiK6vk04Xb3N8ad8eo8am0N/iRgn8V8IS4LyBTyA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/components": "^25.8.14",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/i18n": "^4.42.13",
+        "@wordpress/icons": "^9.33.13",
+        "@wordpress/keyboard-shortcuts": "^4.19.13",
+        "@wordpress/private-apis": "^0.24.13",
+        "classnames": "^2.3.1",
+        "cmdk": "^0.2.0",
+        "rememo": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/commands/node_modules/@wordpress/private-apis": {
+      "version": "0.24.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.24.13.tgz",
+      "integrity": "sha512-RgvGB6VQpPnEGU8Y61tzpgPFYDRAW28+2gcdOXYiqSVdZfGBL6+hBs5bMbLSJYRU9G5pl5q4Eb0lHlkMgHW5FA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/components": {
+      "version": "25.16.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-25.16.0.tgz",
+      "integrity": "sha512-voQuMsO5JbH+JW33TnWurwwvpSb8IQ4XU5wyVMubX4TUwadt+/2ToNJbZIDXoaJPei7vbM81Ft+pH+zGlN8CyA==",
+      "dev": true,
+      "dependencies": {
+        "@ariakit/react": "^0.3.12",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.1",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.2.24",
+        "@wordpress/a11y": "^3.50.0",
+        "@wordpress/compose": "^6.27.0",
+        "@wordpress/date": "^4.50.0",
+        "@wordpress/deprecated": "^3.50.0",
+        "@wordpress/dom": "^3.50.0",
+        "@wordpress/element": "^5.27.0",
+        "@wordpress/escape-html": "^2.50.0",
+        "@wordpress/hooks": "^3.50.0",
+        "@wordpress/html-entities": "^3.50.0",
+        "@wordpress/i18n": "^4.50.0",
+        "@wordpress/icons": "^9.41.0",
+        "@wordpress/is-shallow-equal": "^4.50.0",
+        "@wordpress/keycodes": "^3.50.0",
+        "@wordpress/primitives": "^3.48.0",
+        "@wordpress/private-apis": "^0.32.0",
+        "@wordpress/rich-text": "^6.27.0",
+        "@wordpress/warning": "^2.50.0",
+        "change-case": "^4.1.2",
+        "classnames": "^2.3.1",
+        "colord": "^2.7.0",
+        "date-fns": "^2.28.0",
+        "deepmerge": "^4.3.0",
+        "dom-scroll-into-view": "^1.2.1",
+        "downshift": "^6.0.15",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^10.13.0",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "reakit": "^1.3.11",
+        "remove-accents": "^0.5.0",
+        "use-lilius": "^2.0.1",
+        "uuid": "^9.0.1",
+        "valtio": "1.7.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/components/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
         "@types/mousetrap": "^1.6.8",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/dom": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/keycodes": "^4.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/undo-manager": "^1.3.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
         "change-case": "^4.1.2",
         "clipboard": "^2.0.11",
         "mousetrap": "^1.6.5",
         "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
+        "node": ">=12"
       },
       "peerDependencies": {
         "react": "^18.0.0"
       }
     },
-    "packages/query-include-exclude/node_modules/@wordpress/data": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.3.0.tgz",
-      "integrity": "sha512-cImJw4k30coosH6QtiJllxEYr93w8981PPvhGhemMbRQ28MnSA7rbJPv3h2LO9oss5SQH1gU9kwNGAZcF6PMPg==",
+    "packages/query-include-exclude/node_modules/@wordpress/components/node_modules/@wordpress/hooks": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
+      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/components/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/compose": "^7.3.0",
-        "@wordpress/deprecated": "^4.3.0",
-        "@wordpress/element": "^6.3.0",
-        "@wordpress/is-shallow-equal": "^5.3.0",
-        "@wordpress/priority-queue": "^3.3.0",
-        "@wordpress/private-apis": "^1.3.0",
-        "@wordpress/redux-routine": "^5.3.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/components/node_modules/@wordpress/private-apis": {
+      "version": "0.32.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.32.0.tgz",
+      "integrity": "sha512-P7nxI/bGMDQhtlTfSe1Y2SDfrd20K5UMnTHbq+hmIkzBGRpNPbdGeNu2bZaZtIvmXk1OCR0Fkef+e6QqkOfYPg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/compose": {
+      "version": "6.19.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.19.13.tgz",
+      "integrity": "sha512-3HDdccND+EoEr7tHQ75eCDh07e5TdFh0KFIdWGweq9gU5Z/tssRW8QEyU9J+xEz+DTL/hvFilQ681f58eUZi1g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/dom": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/is-shallow-equal": "^4.42.13",
+        "@wordpress/keycodes": "^3.42.13",
+        "@wordpress/priority-queue": "^2.42.13",
+        "@wordpress/undo-manager": "^0.2.13",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.8",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/compose/node_modules/@wordpress/undo-manager": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.2.13.tgz",
+      "integrity": "sha512-SFIYRs65GEjr0eeh7BZcETaH32qQVm78aFMZXnYTHzBmTXxoJ98XRgEGWXRJU92RXBcjom+1gARKChJoV5dlNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/is-shallow-equal": "^4.42.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/core-data": {
+      "version": "6.19.14",
+      "resolved": "https://registry.npmjs.org/@wordpress/core-data/-/core-data-6.19.14.tgz",
+      "integrity": "sha512-wdstu/qMBKwXnFRX4wMeTkxvHsOgbXm7ZJ0Lgtj+jE86O086Ook7suxacOdMcCaAKNCfMqoGBHtjsNQk3SWE1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/api-fetch": "^6.39.13",
+        "@wordpress/block-editor": "^12.10.14",
+        "@wordpress/blocks": "^12.19.13",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/data": "^9.12.13",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/html-entities": "^3.42.13",
+        "@wordpress/i18n": "^4.42.13",
+        "@wordpress/is-shallow-equal": "^4.42.13",
+        "@wordpress/private-apis": "^0.24.13",
+        "@wordpress/sync": "^0.4.13",
+        "@wordpress/undo-manager": "^0.2.13",
+        "@wordpress/url": "^3.43.13",
+        "change-case": "^4.1.2",
+        "equivalent-key-map": "^0.2.2",
+        "fast-deep-equal": "^3.1.3",
+        "memize": "^2.1.0",
+        "rememo": "^4.0.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/core-data/node_modules/@wordpress/private-apis": {
+      "version": "0.24.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.24.13.tgz",
+      "integrity": "sha512-RgvGB6VQpPnEGU8Y61tzpgPFYDRAW28+2gcdOXYiqSVdZfGBL6+hBs5bMbLSJYRU9G5pl5q4Eb0lHlkMgHW5FA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/core-data/node_modules/@wordpress/undo-manager": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-0.2.13.tgz",
+      "integrity": "sha512-SFIYRs65GEjr0eeh7BZcETaH32qQVm78aFMZXnYTHzBmTXxoJ98XRgEGWXRJU92RXBcjom+1gARKChJoV5dlNw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/is-shallow-equal": "^4.42.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/data": {
+      "version": "9.12.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.12.13.tgz",
+      "integrity": "sha512-8SIsPFrnQ1LIZRWseOF+9uQ9thy8oB7NSOq+bkRCo+qldagooBTZUFp8Y++evFbPOotmTy6XGSPYf7HV9qBHVw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.19.13",
+        "@wordpress/deprecated": "^3.42.13",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/is-shallow-equal": "^4.42.13",
+        "@wordpress/priority-queue": "^2.42.13",
+        "@wordpress/private-apis": "^0.24.13",
+        "@wordpress/redux-routine": "^4.42.13",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "turbo-combine-reducers": "^1.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/data/node_modules/@wordpress/private-apis": {
+      "version": "0.24.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-0.24.13.tgz",
+      "integrity": "sha512-RgvGB6VQpPnEGU8Y61tzpgPFYDRAW28+2gcdOXYiqSVdZfGBL6+hBs5bMbLSJYRU9G5pl5q4Eb0lHlkMgHW5FA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/dependency-extraction-webpack-plugin": {
+      "version": "4.31.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-4.31.0.tgz",
+      "integrity": "sha512-Xpm8EEhi6e8GL1juYh/70AFbcE/ZVXJ3p47KMkkEsn5t+hG9QHjKe2lTj98v2r3rB+ampoK+whdV1w6gItXYpw==",
+      "dev": true,
+      "dependencies": {
+        "json2php": "^0.0.7",
+        "webpack-sources": "^3.2.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "webpack": "^4.8.3 || ^5.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/e2e-test-utils-playwright": {
+      "version": "0.10.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-0.10.13.tgz",
+      "integrity": "sha512-5zqIsG6Nn6N0DBlK9GyvYKxUrK7dEBHFInRnIqqfimWAQmz07iBCJU34njs9lQi+/GzKfXS+2XgBI7dDQnbfwQ==",
+      "dev": true,
+      "dependencies": {
+        "@wordpress/api-fetch": "^6.39.13",
+        "@wordpress/keycodes": "^3.42.13",
+        "@wordpress/url": "^3.43.13",
+        "change-case": "^4.1.2",
+        "form-data": "^4.0.0",
+        "get-port": "^5.1.1",
+        "lighthouse": "^10.4.0",
+        "mime": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/eslint-plugin": {
+      "version": "16.0.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-16.0.13.tgz",
+      "integrity": "sha512-Qk5Y7ifT0lfOOx5RQrEGa/DSw01CP+D2bCKr20SXLt3KDstViBlqjBiI1Yxv7EeS+AvaNbQO5M8Mm4B5mUB3kQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/eslint-parser": "^7.16.0",
+        "@typescript-eslint/eslint-plugin": "^6.4.1",
+        "@typescript-eslint/parser": "^6.4.1",
+        "@wordpress/babel-preset-default": "^7.26.13",
+        "@wordpress/prettier-config": "^2.25.13",
+        "cosmiconfig": "^7.0.0",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-jest": "^27.2.3",
+        "eslint-plugin-jsdoc": "^46.4.6",
+        "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-playwright": "^0.15.3",
+        "eslint-plugin-prettier": "^5.0.0",
+        "eslint-plugin-react": "^7.27.0",
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "globals": "^13.12.0",
+        "requireindex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.14.4"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7",
+        "eslint": ">=8",
+        "prettier": ">=2",
+        "typescript": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "prettier": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/hooks": {
+      "version": "3.42.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.42.13.tgz",
+      "integrity": "sha512-KITkyj2DhbbBevqLzGx4GCtq8XX/GjkMWe0NP7SkcX9d4rkEdON96eKwwoMUD6keL03Tijg87kIYZAU5Xsr8bA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/icons": {
+      "version": "9.33.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.33.13.tgz",
+      "integrity": "sha512-4M34sMRIlyL7a3CDRI7rAfysZQm2VW1ptB4aGDf5tVMXd//hCRkj/OGE++AYkTYQNckli9uqhTkv2xoOOw1F6Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.19.13",
+        "@wordpress/primitives": "^3.40.13"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/keyboard-shortcuts": {
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/keyboard-shortcuts/-/keyboard-shortcuts-4.35.0.tgz",
+      "integrity": "sha512-DR+fWhHt67GQT6PlrfMBpSmEYNCep+XvMYA55cnxoQ80LIFN5N5bkr4VeYdbrSatuOSRACm+6cfoQSIMQbdmjw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/keycodes": "^3.58.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/keyboard-shortcuts/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
         "deepmerge": "^4.3.0",
         "equivalent-key-map": "^0.2.2",
         "is-plain-object": "^5.0.0",
@@ -27790,193 +23196,777 @@
         "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
+        "node": ">=12"
       },
       "peerDependencies": {
         "react": "^18.0.0"
       }
     },
-    "packages/query-include-exclude/node_modules/@wordpress/deprecated": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.3.0.tgz",
-      "integrity": "sha512-K2GHXlwjx6GMhZjs52X1MXySCrqzh4IjoqF5IOcydMgWqOIE2++hMuB9Y55qN/Mhsrv/HO8Q1LaTxbEd6BuNJQ==",
+    "packages/query-include-exclude/node_modules/@wordpress/notices": {
+      "version": "4.26.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-4.26.0.tgz",
+      "integrity": "sha512-Lu98xQdtZHgC3d32IFalZbOiIu8aRFWlEQXXfRutD7EhXXp6FIXvnvc054700/Dk1mg9P/bWd0zm/cigkXgfkA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0"
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/data": "^9.28.0"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/dom": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.3.0.tgz",
-      "integrity": "sha512-sf4h6jVqboRdhe3soyr5bt+Vpz24WG/AIMHm7pGaxfbV5jxx06ZZ8K1RKzhr7jF3wn7IgIc1wmMA+OFzEYqGyw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/deprecated": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/element": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.3.0.tgz",
-      "integrity": "sha512-DsiqzjuXqxJkLUoLomsGTFFxbSZgk+Lz+2/1yFH+BU3jQ6zeD64+JWv8Lt4+fKU154rV0KpfMwfD/oAC/Lp1zQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@types/react": "^18.2.79",
-        "@types/react-dom": "^18.2.25",
-        "@wordpress/escape-html": "^3.3.0",
-        "change-case": "^4.1.2",
-        "is-plain-object": "^5.0.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/escape-html": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.3.0.tgz",
-      "integrity": "sha512-Wu/Fq96E28UGnIO5VQW/aEgCiHWvzrD8izDnP8U0WZSuwIPYcS5iYmRe2UWc7rwyoeY2YXNd6xFjgd7oTOKNCA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/hooks": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.3.0.tgz",
-      "integrity": "sha512-bpqwSXGyxPfhuxESKoAtL4ofB3CazzvcwcucTZ0g9Pat3KNuBaloSrPBliqqNOiSLWNH3nmpkaRmv4u89EdKAw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/i18n": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-5.3.0.tgz",
-      "integrity": "sha512-edHKkdZb6jNpbn+LUPu2wo1mKyhT819WJ7kI8hmMcHq82rNwwbMfcGoB3oSaphTphWfhlgxIxLczKOAbWDKudw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/hooks": "^4.3.0",
-        "gettext-parser": "^1.3.1",
-        "memize": "^2.1.0",
-        "sprintf-js": "^1.1.1",
-        "tannin": "^1.2.0"
-      },
-      "bin": {
-        "pot-to-php": "tools/pot-to-php.js"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/is-shallow-equal": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.3.0.tgz",
-      "integrity": "sha512-sZ+fypqjYX0/DTAKsm1G9ND9Wn4d3Ju4lI7SLSmCKdUL5EPY3g/2LpKQKDqljh9m6Ex5NWp2XfU8UVXpkEfbMQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/keycodes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.3.0.tgz",
-      "integrity": "sha512-o+L110/Y9ufS2eWVG1gXFs6+jPsMNVZoGJCt4PLjMmVabke0iaYstFppUdtQiOEDbnnhX9MH3RRtqp2AoSnaRQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "@wordpress/i18n": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/priority-queue": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.3.0.tgz",
-      "integrity": "sha512-H7dGei1mFqKlz7NLFOGGtVgaBsORRaXeXNwWLI5rE0pI3XfGYd+zxNrG5aBzHw4fPqsITsxecNSaacc9fjqgjQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "requestidlecallback": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/private-apis": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.3.0.tgz",
-      "integrity": "sha512-IbtH8ZENAKixSoTBKbmJ2ZCIkxsxqAoWPBtvbNJG9rYdzSk+BExdy/5VGO6Pv5GcUElHT+8uV26W4XxBVNl4UQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
-      }
-    },
-    "packages/query-include-exclude/node_modules/@wordpress/redux-routine": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.3.0.tgz",
-      "integrity": "sha512-5HGdW8PqIK5fTyg1yo6NL2x1LTxU9vBvgUan/bLxYLX0YNw4+gQUex3djE0dwXNgrdE4mvWvYTcccc+2L59hig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/runtime": "^7.16.0",
-        "is-plain-object": "^5.0.0",
-        "is-promise": "^4.0.0",
-        "rungen": "^0.3.2"
-      },
-      "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
+        "node": ">=12"
       },
       "peerDependencies": {
-        "redux": ">=4"
+        "react": "^18.0.0"
       }
     },
-    "packages/query-include-exclude/node_modules/@wordpress/undo-manager": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.3.0.tgz",
-      "integrity": "sha512-1XvU3GKpWeKFLCRx/3yEttRbIszD38vfH53XmCq2Y6IbWiyJLUGCnq4kiZjOaxA0o/DcAa4edscPyqmJj+wE+g==",
+    "packages/query-include-exclude/node_modules/@wordpress/notices/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.16.0",
-        "@wordpress/is-shallow-equal": "^5.3.0"
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
       },
       "engines": {
-        "node": ">=18.12.0",
-        "npm": ">=8.19.2"
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/notices/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences": {
+      "version": "3.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/preferences/-/preferences-3.35.0.tgz",
+      "integrity": "sha512-OFzSEiI8Kk5YJtyPFnAauRHXtjuTJHkWapvcagpMoTP0WvwBwGfr5AeIIgV2ONtA3edrfMGgmrJUK7pd61K/1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/components": "^27.6.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/data": "^9.28.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "clsx": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/@wordpress/components": {
+      "version": "27.6.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/components/-/components-27.6.0.tgz",
+      "integrity": "sha512-f+fXENkgrPs5GLo2yu9fEAdVX0KriEatRcjDUyw0+DbNbJR62sCdDtGdhJRW4jPUUoUowxaGO0y4+jvQWxnbyg==",
+      "dev": true,
+      "dependencies": {
+        "@ariakit/react": "^0.3.12",
+        "@babel/runtime": "^7.16.0",
+        "@emotion/cache": "^11.7.1",
+        "@emotion/css": "^11.7.1",
+        "@emotion/react": "^11.7.1",
+        "@emotion/serialize": "^1.0.2",
+        "@emotion/styled": "^11.6.0",
+        "@emotion/utils": "^1.0.0",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@types/gradient-parser": "0.1.3",
+        "@types/highlight-words-core": "1.2.1",
+        "@use-gesture/react": "^10.3.1",
+        "@wordpress/a11y": "^3.58.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/date": "^4.58.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/escape-html": "^2.58.0",
+        "@wordpress/hooks": "^3.58.0",
+        "@wordpress/html-entities": "^3.58.0",
+        "@wordpress/i18n": "^4.58.0",
+        "@wordpress/icons": "^9.49.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/primitives": "^3.56.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/rich-text": "^6.35.0",
+        "@wordpress/warning": "^2.58.0",
+        "change-case": "^4.1.2",
+        "clsx": "^2.1.1",
+        "colord": "^2.7.0",
+        "date-fns": "^3.6.0",
+        "deepmerge": "^4.3.0",
+        "downshift": "^6.0.15",
+        "fast-deep-equal": "^3.1.3",
+        "framer-motion": "^11.1.9",
+        "gradient-parser": "^0.1.5",
+        "highlight-words-core": "^1.2.2",
+        "is-plain-object": "^5.0.0",
+        "memize": "^2.1.0",
+        "path-to-regexp": "^6.2.1",
+        "re-resizable": "^6.4.0",
+        "react-colorful": "^5.3.1",
+        "remove-accents": "^0.5.0",
+        "use-lilius": "^2.0.5",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/@wordpress/compose": {
+      "version": "6.35.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-6.35.0.tgz",
+      "integrity": "sha512-PfruhCxxxJokDQHc2YBgerEiHV7BIxQk9g5vU4/f9X/0PBQWUTuxOzSFcAba03vnjfAgtPTSMp50T50hcJwXfA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@types/mousetrap": "^1.6.8",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/dom": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/keycodes": "^3.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/undo-manager": "^0.18.0",
+        "change-case": "^4.1.2",
+        "clipboard": "^2.0.11",
+        "mousetrap": "^1.6.5",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/@wordpress/data": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/data/-/data-9.28.0.tgz",
+      "integrity": "sha512-EDPpZdkngdoW7EMzPpGj0BmNcr7syJO67pgTODtN/4XFIdYL2RKzFyn3nlLBKhX17UsE/ALq9WdijacH4QJ9qw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/compose": "^6.35.0",
+        "@wordpress/deprecated": "^3.58.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/is-shallow-equal": "^4.58.0",
+        "@wordpress/priority-queue": "^2.58.0",
+        "@wordpress/private-apis": "^0.40.0",
+        "@wordpress/redux-routine": "^4.58.0",
+        "deepmerge": "^4.3.0",
+        "equivalent-key-map": "^0.2.2",
+        "is-plain-object": "^5.0.0",
+        "is-promise": "^4.0.0",
+        "redux": "^4.1.2",
+        "rememo": "^4.0.2",
+        "use-memo-one": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/@wordpress/hooks": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-3.58.0.tgz",
+      "integrity": "sha512-9LB0ZHnZRQlORttux9t/xbAskF+dk2ujqzPGsVzc92mSKpQP3K2a5Wy74fUnInguB1vLUNHT6nrNdkVom5qX1Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/@wordpress/icons": {
+      "version": "9.49.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-9.49.0.tgz",
+      "integrity": "sha512-Z8F+ledkfkcKDuS1c/RkM0dEWdfv2AXs6bCgey89p0atJSscf7qYbMJR9zE5rZ5aqXyFfV0DAFKJEgayNqneNQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "@wordpress/element": "^5.35.0",
+        "@wordpress/primitives": "^3.56.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/preferences/node_modules/framer-motion": {
+      "version": "11.3.8",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.3.8.tgz",
+      "integrity": "sha512-1D+RDTsIp4Rz2dq/oToqSEc9idEQwgBRQyBq4rGpFba+0Z+GCbj9z1s0+ikFbanWe3YJ0SqkNlDe08GcpFGj5A==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/prettier-config": {
+      "version": "2.25.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-2.25.13.tgz",
+      "integrity": "sha512-iz58o0X91E24j0VFtzwn5qG84w+s4VlRCuZWa/lPL6pfGtOSw30c60wCrYKCA1IWIIAWdpRAYfEh7errPyKiPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "prettier": ">=2"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/scripts": {
+      "version": "26.13.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-26.13.13.tgz",
+      "integrity": "sha512-G2K56PmjRPI0ddgmrnopp3AVMLACqfrFvz+NyGbYCPWQoYL3xnphrS+w3uPwuxcuBtgR34yr+xCvrMnJsY3Wag==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.16.0",
+        "@pmmmwh/react-refresh-webpack-plugin": "^0.5.2",
+        "@svgr/webpack": "^8.0.1",
+        "@wordpress/babel-preset-default": "^7.26.13",
+        "@wordpress/browserslist-config": "^5.25.13",
+        "@wordpress/dependency-extraction-webpack-plugin": "^4.25.13",
+        "@wordpress/e2e-test-utils-playwright": "^0.10.13",
+        "@wordpress/eslint-plugin": "^16.0.13",
+        "@wordpress/jest-preset-default": "^11.13.13",
+        "@wordpress/npm-package-json-lint-config": "^4.27.13",
+        "@wordpress/postcss-plugins-preset": "^4.26.13",
+        "@wordpress/prettier-config": "^2.25.13",
+        "@wordpress/stylelint-config": "^21.25.13",
+        "adm-zip": "^0.5.9",
+        "babel-jest": "^29.6.2",
+        "babel-loader": "^8.2.3",
+        "browserslist": "^4.21.9",
+        "chalk": "^4.0.0",
+        "check-node-version": "^4.1.0",
+        "clean-webpack-plugin": "^3.0.0",
+        "copy-webpack-plugin": "^10.2.0",
+        "cross-spawn": "^5.1.0",
+        "css-loader": "^6.2.0",
+        "cssnano": "^6.0.1",
+        "cwd": "^0.10.0",
+        "dir-glob": "^3.0.1",
+        "eslint": "^8.3.0",
+        "expect-puppeteer": "^4.4.0",
+        "fast-glob": "^3.2.7",
+        "filenamify": "^4.2.0",
+        "jest": "^29.6.2",
+        "jest-dev-server": "^6.0.2",
+        "jest-environment-jsdom": "^29.6.2",
+        "jest-environment-node": "^29.6.2",
+        "markdownlint-cli": "^0.31.1",
+        "merge-deep": "^3.0.3",
+        "mini-css-extract-plugin": "^2.5.1",
+        "minimist": "^1.2.0",
+        "npm-package-json-lint": "^6.4.0",
+        "npm-packlist": "^3.0.0",
+        "playwright-core": "1.32.0",
+        "postcss": "^8.4.5",
+        "postcss-loader": "^6.2.1",
+        "prettier": "npm:wp-prettier@3.0.3-beta-3",
+        "puppeteer-core": "^13.2.0",
+        "react-refresh": "^0.10.0",
+        "read-pkg-up": "^7.0.1",
+        "resolve-bin": "^0.4.0",
+        "sass": "^1.35.2",
+        "sass-loader": "^12.1.0",
+        "source-map-loader": "^3.0.0",
+        "stylelint": "^14.2.0",
+        "terser-webpack-plugin": "^5.3.9",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.47.1",
+        "webpack-bundle-analyzer": "^4.4.2",
+        "webpack-cli": "^4.9.1",
+        "webpack-dev-server": "^4.4.0"
+      },
+      "bin": {
+        "wp-scripts": "bin/wp-scripts.js"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6.14.4"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.32.0",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/scripts/node_modules/prettier": {
+      "name": "wp-prettier",
+      "version": "3.0.3-beta-3",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3-beta-3.tgz",
+      "integrity": "sha512-R3+TD7j0rnqEpMgylrUrHdi1W6ypwh4QGeFOZQ9YjP9WvNnZzBAS71yry1h7xIcG/bVaNKBCoWNqbqJY6vkOKQ==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/shortcode": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/shortcode/-/shortcode-3.58.0.tgz",
+      "integrity": "sha512-yM3Y25XqLfz/X6xXowXbrTvk+tslKeALNNESI5nGt1X7wWPsYQDOqyBb1HT9TglSLFgWYlQlNtgEbz07dEiDgQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "memize": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/style-engine": {
+      "version": "1.41.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/style-engine/-/style-engine-1.41.0.tgz",
+      "integrity": "sha512-aM5bbJn6m8SHRotCoh/fSGuIB0MQJoVFBjpzIDoUDQ1KlO7CbY+fj9daDV1FZPMNv0h0ZEFWZ+y7Gv/CERypMA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "change-case": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/sync": {
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/@wordpress/sync/-/sync-0.4.13.tgz",
+      "integrity": "sha512-3Lq7MENUpCaSvR6WOLOovNmRMXGmFcdnbMjSZlHh0sx3ycWbKpXlGyfQWJ20MZRiO/qTOOrj4VW4GejqqJSEZw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "y-indexeddb": "~9.0.11",
+        "y-webrtc": "~10.2.5",
+        "yjs": "~13.6.6"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/token-list": {
+      "version": "2.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/token-list/-/token-list-2.58.0.tgz",
+      "integrity": "sha512-xzNGzAZ87GERq7rZvZjMv742nj37tSLFBb8+c7oaLdpUpfn8YTaXQacvphdN2jmtfHvEZHivW7hErwqF9eQW/A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/url": {
+      "version": "3.59.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/url/-/url-3.59.0.tgz",
+      "integrity": "sha512-GxvoMjYCav0w4CiX0i0h3qflrE/9rhLIZg5aPCQjbrBdwTxYR3Exfw0IJYcmVaTKXQOUU8fOxlDxULsbLmKe9w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0",
+        "remove-accents": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/@wordpress/wordcount": {
+      "version": "3.58.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/wordcount/-/wordcount-3.58.0.tgz",
+      "integrity": "sha512-cxmOOh8d4VeIC3B9HcqhlTQePmNkNrPeHQLj6xWHfC0Elflj+kYAjsTwkjVQ3tBMC4+mQzva1O8tFSVh02gs7w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.16.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/query-include-exclude/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
+    "packages/query-include-exclude/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "packages/query-include-exclude/node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/query-include-exclude/node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
+    "packages/query-include-exclude/node_modules/framer-motion": {
+      "version": "10.18.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.18.0.tgz",
+      "integrity": "sha512-oGlDh1Q1XqYPksuTD/usb0I70hq95OUzmL9+6Zd+Hs4XV0oaISBa/UUMSjYiq6m8EUF32132mOJ8xVZS+I0S6w==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "packages/query-include-exclude/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/query-include-exclude/node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "packages/query-include-exclude/node_modules/jest-dev-server": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jest-dev-server/-/jest-dev-server-6.2.0.tgz",
+      "integrity": "sha512-ZWh8CuvxwjhYfvw4tGeftziqIvw/26R6AG3OTgNTQeXul8aZz48RQjDpnlDwnWX53jxJJl9fcigqIdSU5lYZuw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "cwd": "^0.10.0",
+        "find-process": "^1.4.7",
+        "prompts": "^2.4.2",
+        "spawnd": "^6.2.0",
+        "tree-kill": "^1.2.2",
+        "wait-on": "^6.0.1"
+      }
+    },
+    "packages/query-include-exclude/node_modules/playwright-core": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+      "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "packages/query-include-exclude/node_modules/react-easy-crop": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-4.7.5.tgz",
+      "integrity": "sha512-qKfI4PuhaH1jOLC3DQfQB0cE0z+3N7bfyPkPejQmylXNb8nstfPMH+oHj3gKgpBHLFUiQp/C1rY7sVCVgtjn3Q==",
+      "dev": true,
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/react-easy-crop/node_modules/tslib": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+      "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==",
+      "dev": true
+    },
+    "packages/query-include-exclude/node_modules/react-refresh": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.10.0.tgz",
+      "integrity": "sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/rechoir": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+      "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+      "dev": true,
+      "dependencies": {
+        "resolve": "^1.9.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "packages/query-include-exclude/node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/query-include-exclude/node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/query-include-exclude/node_modules/spawnd": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/spawnd/-/spawnd-6.2.0.tgz",
+      "integrity": "sha512-qX/I4lQy4KgVEcNle0kuc4FxFWHISzBhZW1YemPfwmrmQjyZmfTK/OhBKkhrD2ooAaFZEm1maEBLE6/6enwt+g==",
+      "dev": true,
+      "dependencies": {
+        "exit": "^0.1.2",
+        "signal-exit": "^3.0.7",
+        "tree-kill": "^1.2.2"
+      }
+    },
+    "packages/query-include-exclude/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/query-include-exclude/node_modules/wait-on": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/wait-on/-/wait-on-6.0.1.tgz",
+      "integrity": "sha512-zht+KASY3usTY5u2LgaNqn/Cd8MukxLGjdcZxT2ns5QzDmTFc4XoWBgC+C/na+sMRZTuVygQoMYwdcVjHnYIVw==",
+      "dev": true,
+      "dependencies": {
+        "axios": "^0.25.0",
+        "joi": "^17.6.0",
+        "lodash": "^4.17.21",
+        "minimist": "^1.2.5",
+        "rxjs": "^7.5.4"
+      },
+      "bin": {
+        "wait-on": "bin/wait-on"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "packages/query-include-exclude/node_modules/webpack-cli": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+      "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+      "dev": true,
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.5.0",
+        "@webpack-cli/configtest": "^1.2.0",
+        "@webpack-cli/info": "^1.5.0",
+        "@webpack-cli/serve": "^1.7.0",
+        "colorette": "^2.0.14",
+        "commander": "^7.0.0",
+        "cross-spawn": "^7.0.3",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^2.2.0",
+        "rechoir": "^0.7.0",
+        "webpack-merge": "^5.7.3"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "4.x.x || 5.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@webpack-cli/generators": {
+          "optional": true
+        },
+        "@webpack-cli/migrate": {
+          "optional": true
+        },
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "packages/query-include-exclude/node_modules/webpack-cli/node_modules/cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "packages/query-include-exclude/node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "type-coverage": "turbo run type-coverage"
   },
   "devDependencies": {
-    "turbo": "^2.0.7"
+    "turbo": "^2.0.7",
+    "webpack-cli": "^5.1.4"
   },
   "packageManager": "npm@10.8.1+sha512.0e9d42e92bd2318408ed81eaff2da5f78baf23ee7d12a6eed44a6e2901d0f29d7ab715d1b918ade601f72e769a824d9a5c322383f22bbbda5dd396e79de2a077"
 }

--- a/packages/editor-tools/editor-tools.php
+++ b/packages/editor-tools/editor-tools.php
@@ -5,6 +5,7 @@
  * Version: 1.0.0
  * Author: BoxUK
  * Author URI: https://boxuk.com
+ * Requires at least: 6.4 
  *
  * @package Boxuk\BoxWpEditorTools
  */

--- a/packages/iconography/iconography.php
+++ b/packages/iconography/iconography.php
@@ -5,6 +5,7 @@
  * Version: 1.0.0
  * Author: BoxUK
  * Author URI: https://www.boxuk.com
+ * Requires at least: 6.4
  *
  * @package Boxuk\Iconography
  */

--- a/packages/iconography/package.json
+++ b/packages/iconography/package.json
@@ -13,7 +13,7 @@
 		"lint:fix": "wp-scripts lint-js --fix",
 		"test": "wp-scripts test-unit-js",
 		"test:snapshots": "wp-scripts test-unit-js --updateSnapshot",
-		"packages-update": "wp-scripts packages-update",
+		"packages-update": "wp-scripts packages-update --dist-tag=wp-6.4",
 		"start": "wp-scripts start",
 		"type-coverage": "type-coverage --strict --detail --at-least 97.5"
 	},
@@ -23,11 +23,11 @@
 		"@jest/globals": "^29.7.0",
 		"@testing-library/react": "^16.0.0",
 		"@types/wordpress__block-editor": "^11.5.15",
-		"@wordpress/dom-ready": "^4.3.0",
-		"@wordpress/editor": "^14.3.0",
-		"@wordpress/icons": "^10.3.0",
-		"@wordpress/interface": "^6.3.0",
-		"@wordpress/scripts": "^27.8.0",
+		"@wordpress/dom-ready": "^3.42.13",
+		"@wordpress/editor": "^13.19.14",
+		"@wordpress/icons": "^9.33.13",
+		"@wordpress/interface": "^5.19.14",
+		"@wordpress/scripts": "^26.13.13",
 		"react": "^18.2.0",
 		"type-coverage": "^2.29.1"
 	}

--- a/packages/query-include-exclude/package.json
+++ b/packages/query-include-exclude/package.json
@@ -13,7 +13,7 @@
 		"lint:fix": "wp-scripts lint-js --fix",
 		"test": "wp-scripts test-unit-js --passWithNoTests",
 		"test:snapshots": "wp-scripts test-unit-js --updateSnapshot",
-		"packages-update": "wp-scripts packages-update",
+		"packages-update": "wp-scripts packages-update --dist-tag=wp-6.4",
 		"start": "wp-scripts start",
 		"type-coverage": "type-coverage --strict --detail --at-least 97.5"
 	},
@@ -22,14 +22,14 @@
 	"devDependencies": {
 		"@jest/globals": "^29.7.0",
 		"@testing-library/react": "^16.0.0",
-		"@wordpress/data": "^10.3.0",
-		"@wordpress/core-data": "^7.3.0",
-		"@wordpress/blocks": "^13.3.0",
-		"@wordpress/block-editor": "^13.3.0",
-		"@wordpress/compose": "^7.3.0",
-		"@wordpress/hooks": "^4.3.0",
-		"@wordpress/icons": "^10.3.0",
-		"@wordpress/scripts": "^27.8.0",
+		"@wordpress/block-editor": "^12.10.14",
+		"@wordpress/blocks": "^12.19.13",
+		"@wordpress/compose": "^6.19.13",
+		"@wordpress/core-data": "^6.19.14",
+		"@wordpress/data": "^9.12.13",
+		"@wordpress/hooks": "^3.42.13",
+		"@wordpress/icons": "^9.33.13",
+		"@wordpress/scripts": "^26.13.13",
 		"react": "^18.2.0",
 		"type-coverage": "^2.29.1"
 	}

--- a/packages/query-include-exclude/query-include-exclude.php
+++ b/packages/query-include-exclude/query-include-exclude.php
@@ -5,6 +5,7 @@
  * Version: 1.0.0
  * Author: BoxUK
  * Author URI: https://boxuk.com
+ * Requires at least: 6.4
  * 
  * @package Boxuk\QueryIncludeExclude
  */

--- a/packages/query-include-exclude/src/AdditionalControls.tsx
+++ b/packages/query-include-exclude/src/AdditionalControls.tsx
@@ -27,12 +27,12 @@ export const AdditionalControls = ( {
 	 * @param includes
 	 */
 	const setQueryIncludes = ( includes: number[] ) => {
-		setAttributes( {
-			query: {
-				...query,
-				include: includes.length ? includes : undefined,
-			},
-		} );
+		if ( includes.length > 0 ) {
+			setAttributes( { query: { ...query, include: includes } } );
+		} else {
+			const { include, ...rest } = query || {};
+			setAttributes( { query: rest } );
+		}
 	};
 
 	/**

--- a/packages/query-include-exclude/src/SelectPostsControl.tsx
+++ b/packages/query-include-exclude/src/SelectPostsControl.tsx
@@ -72,7 +72,7 @@ export const SelectPostsControl = ( {
 	return (
 		<FormTokenField
 			label={ label }
-			value={ selectedPosts.map( ( post: Post ) => post.title.rendered ) }
+			value={ selectedPosts.map( postToTitleWithId ) }
 			suggestions={ allPosts.map( postToTitleWithId ) }
 			onChange={ handleChange }
 			tokenizeOnBlur={ false }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -9,5 +9,6 @@ parameters:
     analyse:
       - packages/vendor
       - /**/tests/*
+      - /**/node_modules/*
     analyseAndScan:
       - packages/vendor/10up/wp_mock # WP_Mock functions override the signatures from php-stubs/wordpress


### PR DESCRIPTION
Fixes an issue where selecting multiple posts to include/exclude would fail because we werent including the post ID in the title of the post. 
Fixes an issue where selecing posts to include, then unselecting them and leaving an empty 'includes' array would cause no posts to be included. 