### PR TITLE
[FIX] Template Persistance Disabling

### DIFF
--- a/packages/editor-tools/src/TemplatePersistence.php
+++ b/packages/editor-tools/src/TemplatePersistence.php
@@ -20,10 +20,6 @@ class TemplatePersistence {
 	 * @return void
 	 */
 	public function init(): void {
-		if ( apply_filters( 'boxuk_disable_template_persistence', false ) ) {
-			return;
-		}
-		
 		add_action( 'save_post', array( $this, 'persist_template' ), 10, 2 );
 	}
 
@@ -35,7 +31,13 @@ class TemplatePersistence {
 	 *  
 	 * @return void
 	 */
-	public function persist_template( int $post_id, \WP_Post $post ): void {    
+	public function persist_template( int $post_id, \WP_Post $post ): void { 
+		
+		$default = wp_get_environment_type() !== 'local';
+		if ( apply_filters( 'boxuk_disable_template_persistence', $default ) ) {
+			return;
+		}
+		
 		$filename = $this->get_template_filename( $post );
 		
 		if ( false === $filename || ! $this->is_writeable( $filename ) ) {

--- a/packages/editor-tools/tests/TestTemplatePersistence.php
+++ b/packages/editor-tools/tests/TestTemplatePersistence.php
@@ -51,12 +51,14 @@ class TestTemplatePersistence extends TestCase {
 	 * @return void
 	 */
 	public function test_init_with_disabled_filter(): void {
+		\WP_Mock::userFunction( 'wp_get_environment_type' )
+			->once()
+			->andReturn( 'production' );
 		\WP_Mock::onFilter( 'boxuk_disable_template_persistence' )
-			->with( false )
+			->with( true )
 			->reply( true );
 
-		\WP_Mock::expectActionNotAdded( 'save_post', array( $this->class_in_test, 'persist_template' ), 10, 2 );
-		$this->class_in_test->init();
+		$this->class_in_test->persist_template( 0, $this->getMockPost( 'wp_template' ) );
 		$this->assertConditionsMet();
 	}
 
@@ -76,6 +78,13 @@ class TestTemplatePersistence extends TestCase {
 		bool $expect_template_write,
 		string|bool $template_path
 	) { 
+		\WP_Mock::userFunction( 'wp_get_environment_type' )
+			->once()
+			->andReturn( 'local' );
+		\WP_Mock::onFilter( 'boxuk_disable_template_persistence' )
+			->with( false )
+			->reply( false );
+			
 		if ( $expect_template_write ) {
 			\WP_Mock::userFunction( 'get_stylesheet_directory' )
 				->once()


### PR DESCRIPTION
The filter being used to disable filtering was being called very early in the lifecycle. This made it near impossible for a theme to actually utilise this filter. Moving it inside the save-post hook allows the filter to be utilised.

Also added a default value so that template persistance is only effective on local environments, with the filter being used to ovveride this default value.