### PR TITLE
[FEATURE] Include built-in post-types for template loading

### DIFF
--- a/packages/editor-tools/src/PostTypes.php
+++ b/packages/editor-tools/src/PostTypes.php
@@ -19,6 +19,7 @@ class PostTypes {
 	 */
 	public function init(): void {
 		add_action( 'init', array( $this, 'register_post_types' ) );
+		add_filter( 'register_post_type_args', array( $this, 'modify_post_types' ), 10, 2 );
 	}
 
 	/**
@@ -124,5 +125,25 @@ class PostTypes {
 			$block['attrs'] ?? array(),
 			$this->blocks_to_template( $block['innerBlocks'] ?? array() ),
 		);
+	}
+
+	/**
+	 * Modify built in post types to load templates if they exist.
+	 *
+	 * @param array  $args Array of arguments.
+	 * @param string $post_type Post Type.
+	 * 
+	 * // @phpstan-ignore-next-line -- return shape can't be desribed for phpstan because it's recursive.
+	 */
+	public function modify_post_types( array $args, string $post_type ): array {
+		if ( 'post' !== $post_type && 'page' !== $post_type ) {
+			return $args;
+		}
+
+		$args['template'] = $this->blocks_to_template(
+			$this->get_blocks_from_file( $post_type ) ?? array()
+		) ?? array();
+
+		return $args;
 	}
 }

--- a/packages/editor-tools/tests/TestPostTypes.php
+++ b/packages/editor-tools/tests/TestPostTypes.php
@@ -22,6 +22,7 @@ class TestPostTypes extends TestCase {
 	public function testInit(): void {
 		$post_types = new \Boxuk\BoxWpEditorTools\PostTypes();
 		\WP_Mock::expectActionAdded( 'init', array( $post_types, 'register_post_types' ) );
+		\WP_Mock::expectFilterAdded( 'register_post_type_args', array( $post_types, 'modify_post_types' ), 10, 2 );
 		$post_types->init();
 		$this->assertConditionsMet();
 	}
@@ -232,6 +233,49 @@ class TestPostTypes extends TestCase {
 					),
 				),
 				'expected' => array( array( 'core/paragraph', array(), array() ) ),
+			),
+		);
+	}
+
+	/**
+	 * Test `modify_post_types`
+	 * 
+	 * @dataProvider modify_post_types_provider
+	 * 
+	 * @param string $post_type Post Type.
+	 * @param array  $args Arguments.
+	 * @param array  $expected Expected.
+	 * 
+	 * @return void
+	 */
+	public function testModifyPostTypes( $post_type, $args, $expected ): void {
+		$post_types = new \Boxuk\BoxWpEditorTools\PostTypes();
+		$this->assertEquals( $expected, $post_types->modify_post_types( $args, $post_type ) );
+	}
+
+	/**
+	 * Modify post types provider
+	 * 
+	 * @return array
+	 * 
+	 * phpcs:ignore NeutronStandard.Functions.LongFunction.LongFunction -- This is a data provider
+	 */
+	public function modify_post_types_provider(): array {
+		return array(
+			'not-post-or-page' => array(
+				'post_type' => 'foo',
+				'args'      => array( 'foo' => 'bar' ),
+				'expected'  => array( 'foo' => 'bar' ),
+			),
+			'post'             => array(
+				'post_type' => 'post',
+				'args'      => array(),
+				'expected'  => array( 'template' => array() ),
+			),
+			'page'             => array(
+				'post_type' => 'page',
+				'args'      => array(),
+				'expected'  => array( 'template' => array() ),
 			),
 		);
 	}


### PR DESCRIPTION
The `post` and `page` post-types can now have a template loaded by providing a `{theme}/post-type-templates/post.html` file just like custom post-types.