### PR TITLE
[FIX] Prevent unneceassary JS loading in the frontend

### DIFF
--- a/packages/iconography/includes/IconographyService.php
+++ b/packages/iconography/includes/IconographyService.php
@@ -33,7 +33,7 @@ class IconographyService {
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_assets' ) );
 		add_action( 'wp_footer', array( $this, 'enqueue_assets' ), 1, 0 );
 		add_action( 'enqueue_block_assets', array( $this, 'register_assets' ), 1, 0 );
-		add_action( 'enqueue_block_assets', array( $this, 'enqueue_editor_scripts' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_scripts' ) );
 		add_action( 'enqueue_block_assets', array( $this, 'enqueue_all_assets' ) );
 	}
 

--- a/packages/iconography/tests/TestIcononographyService.php
+++ b/packages/iconography/tests/TestIcononographyService.php
@@ -29,7 +29,7 @@ class TestIcononographyService extends TestCase {
 		\WP_Mock::expectActionAdded( 'wp_enqueue_scripts', array( $class_in_test, 'register_assets' ) );
 		\WP_Mock::expectActionAdded( 'wp_footer', array( $class_in_test, 'enqueue_assets' ), 1, 0 );
 		\WP_Mock::expectActionAdded( 'enqueue_block_assets', array( $class_in_test, 'register_assets' ), 1, 0 );
-		\WP_Mock::expectActionAdded( 'enqueue_block_assets', array( $class_in_test, 'enqueue_editor_scripts' ) );
+		\WP_Mock::expectActionAdded( 'enqueue_block_editor_assets', array( $class_in_test, 'enqueue_editor_scripts' ) );
 		\WP_Mock::expectActionAdded( 'enqueue_block_assets', array( $class_in_test, 'enqueue_all_assets' ) );
 
 		$class_in_test->init();


### PR DESCRIPTION
`enqueue_block_assets` loads on the frontend, meaning we were loading the admin interface on the frontend. This also in turn enqueued a whole heap of dependancies including `react` on the frontend, which had a significant performance impact. 