### PR TITLE
[SETUP] Make WP Package Updater it's own repo

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -26,6 +26,8 @@ jobs:
             target_repo: "wp-consent-management"
           - local_path: "email-tld-checker"
             target_repo: "wordpress-email-tld-checker"
+          - local_path: "deps-auto-update"
+            target_repo: "wp-deps-auto-update"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wordpress-deps.yml
+++ b/.github/workflows/wordpress-deps.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run Update
-        uses: './.github/wp-packages'
+        uses: 'boxuk/wp-deps-auto-update@main'
         with:
           WP_VERSION: ${{ env.WORDPRESS_VERSION }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/deps-auto-update/action.yml
+++ b/packages/deps-auto-update/action.yml
@@ -1,4 +1,4 @@
-name: Update WP Packaes
+name: Update WP Packages
 description: 'Update WP Packages'
 inputs: 
   WP_VERSION: 
@@ -13,12 +13,12 @@ runs:
 
     # Setup the action
     - name: Clone Repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with: 
         fetch-depth: 1
         persist-credentials: false
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
         cache: npm

--- a/packages/deps-auto-update/readme.md
+++ b/packages/deps-auto-update/readme.md
@@ -1,0 +1,47 @@
+# WordPress Deps Auto Updater
+
+This is a simple GitHub Worklfow to run the `update-packages` script from the given repository and create a PR with the output. 
+
+## Usage
+
+Create a `.github/workflows/wordpress-deps.yml` file with the following: 
+
+```yml
+name: Update WP Deps
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+env: 
+  WORDPRESS_VERSION: ${{ vars.WORDPRESS_VERSION }}
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Run Update
+        uses: 'boxuk/wp-deps-auto-update@main'
+        with:
+          WP_VERSION: ${{ env.WORDPRESS_VERSION }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+You could use another technique to determine the WordPress version, such as reading from your `composer.json` file. 
+
+## Contributing
+
+Please do not submit any Pull Requests here. They will be closed.
+---
+
+Please submit your PR here instead: https://github.com/boxuk/wp-packages
+
+This repository is what we call a "subtree split": a read-only subset of that main repository.
+We're looking forward to your PR there!


### PR DESCRIPTION
You can't refer to internal files from external repos, so needs this to be it's own repo, split from the monorepo. 