### PR TITLE
[BWP-100] Bug - Iconography in WP 6.6 re-introduces alignment options.

### DIFF
--- a/packages/iconography/iconography.php
+++ b/packages/iconography/iconography.php
@@ -20,7 +20,7 @@ add_action(
 
 		add_filter(
 			'boxuk_iconography_files',
-			function ( $config_files ) {
+			function ( array $config_files ): array {
 				$plugin_dir = __DIR__;
 
 				$config_files['material-symbols-outlined']        = $plugin_dir . '/config/material-symbols-outlined.config.json';

--- a/packages/iconography/src/block/block.json
+++ b/packages/iconography/src/block/block.json
@@ -12,7 +12,7 @@
 	"editorScript": "file:./index.ts",
 	"supports": {
 		"anchor": false,
-		"align": [],
+		"align": false,
 		"alignWide": false,
 		"ariaLabel": true,
 		"background": {
@@ -46,12 +46,12 @@
 		"spacing": {
 			"margin": true,
 			"padding": true,
-			"blockGrap": false
+			"blockGap": false
 		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": false,
-			"textAlign": true
+			"textAlign": false
 		}
 	},
 	"attributes": {


### PR DESCRIPTION
Removes options that don't work from the icon block