### PR TITLE
[BWP-103] Prepare FF for release

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -28,6 +28,8 @@ jobs:
             target_repo: "wordpress-email-tld-checker"
           - local_path: "deps-auto-update"
             target_repo: "wp-deps-auto-update"
+          - local_path: "feature-flags"
+            target_repo: "wp-feature-flags"
 
     steps:
       - uses: actions/checkout@v4

--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,5 @@
 {
 	"name": "@boxuk/wp-feature-flags",
-	"version": "1.0.0",
 	"description": "",
 	"main": "index.js",
 	"directories": {


### PR DESCRIPTION
Add the FF to auto-deploy via the packages-split, and remove the version from the `package.json` so it's read from the GitHub repo. 